### PR TITLE
Shared memory permissions

### DIFF
--- a/canopen_chain_node/include/canopen_chain_node/chain_ros.h
+++ b/canopen_chain_node/include/canopen_chain_node/chain_ros.h
@@ -57,7 +57,7 @@ public:
     virtual ~Logger() {}
 };
 
-template<typename InterfaceType, typename MasterType> class RosChain : public canopen::LayerStack {
+template<typename InterfaceType> class RosChain : public canopen::LayerStack {
 protected:
     std::string chain_name_;
     

--- a/canopen_chain_node/include/canopen_chain_node/chain_ros.h
+++ b/canopen_chain_node/include/canopen_chain_node/chain_ros.h
@@ -226,19 +226,26 @@ protected:
         
         bus_nh.param("master_type",master_type, std::string("shared"));
 
-        if(master_type == "exclusive"){
-            master_ = boost::make_shared<SharedMaster>(can_device, interface_);
-        }else if (master_type == "shared"){
-            boost::interprocess::permissions perm;
-            perm.set_unrestricted();
-            master_ = boost::make_shared<SharedMaster>(can_device, interface_, perm);
-        }else if (master_type == "local"){
-            master_ = boost::make_shared<LocalMaster>(can_device, interface_);
-        }else{
-            ROS_ERROR_STREAM("Master type  "<< master_type << " is not supported");
+        try{
+            if(master_type == "exclusive"){
+                master_ = boost::make_shared<SharedMaster>(can_device, interface_);
+            }else if (master_type == "shared"){
+                boost::interprocess::permissions perm;
+                perm.set_unrestricted();
+                master_ = boost::make_shared<SharedMaster>(can_device, interface_, perm);
+            }else if (master_type == "local"){
+                master_ = boost::make_shared<LocalMaster>(can_device, interface_);
+            }else{
+                ROS_ERROR_STREAM("Master type  "<< master_type << " is not supported");
+                return false;
+            }
+        }
+        catch( const std::exception &e){
+            std::string info = boost::diagnostic_information(e);
+            ROS_ERROR_STREAM(info);
             return false;
         }
-
+        
         add(boost::make_shared<CANLayer<InterfaceType> >(interface_, can_device, can_bitrate));
         
         return true;

--- a/canopen_chain_node/src/chain_node.cpp
+++ b/canopen_chain_node/src/chain_node.cpp
@@ -10,7 +10,7 @@ int main(int argc, char** argv){
   ros::NodeHandle nh;
   ros::NodeHandle nh_priv("~");
   
-  RosChain<ThreadedSocketCANInterface, SharedMaster> chain(nh, nh_priv);
+  RosChain<ThreadedSocketCANInterface> chain(nh, nh_priv);
   
   if(!chain.setup()){
       return -1;

--- a/canopen_master/include/canopen_master/master.h
+++ b/canopen_master/include/canopen_master/master.h
@@ -296,7 +296,7 @@ class LocalMaster: public Master{
     boost::shared_ptr<can::CommInterface> interface_;
 public:
     virtual boost::shared_ptr<SyncLayer> getSync(const SyncProperties &properties);
-    LocalMaster(const std::string &name, boost::shared_ptr<can::CommInterface> interface) : interface_(interface)  {}
+    LocalMaster(const std::string &name, boost::shared_ptr<can::CommInterface> interface, const boost::interprocess::permissions & perm = boost::interprocess::permissions()) : interface_(interface)  {}
 };
 
 class SharedIPCSyncMaster : public IPCSyncMaster{
@@ -322,9 +322,9 @@ class SharedMaster: public Master{
     boost::unordered_map<can::Header, boost::shared_ptr<SharedIPCSyncMaster> > syncmasters_;
     boost::shared_ptr<can::CommInterface> interface_;
 public:
-    SharedMaster(const std::string &name, boost::shared_ptr<can::CommInterface> interface)
+    SharedMaster(const std::string &name, boost::shared_ptr<can::CommInterface> interface, const boost::interprocess::permissions & perm = boost::interprocess::permissions())
     : name_("canopen_master_shm_"+name), remover_(name_.c_str()),
-        managed_shm_(boost::interprocess::open_or_create, name_.c_str(), 4096),
+        managed_shm_(boost::interprocess::open_or_create, name_.c_str(), 4096, 0, perm),
         interface_(interface)  {}
     virtual boost::shared_ptr<SyncLayer> getSync(const SyncProperties &properties);
 };

--- a/canopen_motor_node/src/control_node.cpp
+++ b/canopen_motor_node/src/control_node.cpp
@@ -414,7 +414,7 @@ public:
 
 };
 
-class MotorChain : RosChain<ThreadedSocketCANInterface, SharedMaster>{
+class MotorChain : RosChain<ThreadedSocketCANInterface>{
     boost::shared_ptr< LayerGroup<MotorNode> > motors_;
     boost::shared_ptr< LayerGroup<HandleLayer> > handle_layer_;
 


### PR DESCRIPTION
Fixes for #53 
- added permission setup
- catch exception during shared memory creation
- added bus/master_type parameter:
  - "shared" [default]: shared master (multi-chain support) for all users
  - "exclusive": shared master (multi-chain support) for single user
  - "local": local master without multi-chain support
