### PR TITLE
DCF overlay feature

### DIFF
--- a/canopen_chain_node/include/canopen_chain_node/chain_ros.h
+++ b/canopen_chain_node/include/canopen_chain_node/chain_ros.h
@@ -327,6 +327,15 @@ protected:
                 return false;
             }
 
+            ObjectDict::Overlay overlay;
+            if(module.hasMember("dcf_overlay")){
+                XmlRpc::XmlRpcValue dcf_overlay = module["dcf_overlay"];
+                for(XmlRpc::XmlRpcValue::iterator it = dcf_overlay.begin(); it!= dcf_overlay.end(); ++it){
+                    overlay.push_back(ObjectDict::Overlay::value_type(it->first, it->second));
+                }
+
+            }
+
             MergedXmlRpcStruct merged(module, defaults);
                             
             std::string eds;
@@ -351,7 +360,7 @@ protected:
             catch(...){
             }
             
-            boost::shared_ptr<ObjectDict>  dict = ObjectDict::fromFile(eds);
+            boost::shared_ptr<ObjectDict>  dict = ObjectDict::fromFile(eds, overlay);
             if(!dict){
                 ROS_ERROR_STREAM("EDS '" << eds << "' could not be parsed");
                 return false;

--- a/canopen_chain_node/include/canopen_chain_node/chain_ros.h
+++ b/canopen_chain_node/include/canopen_chain_node/chain_ros.h
@@ -14,13 +14,21 @@
 namespace canopen{
 
 class MergedXmlRpcStruct : public XmlRpc::XmlRpcValue{
+    MergedXmlRpcStruct(const XmlRpc::XmlRpcValue& a) :XmlRpc::XmlRpcValue(a){ assertStruct(); }
 public:
-    MergedXmlRpcStruct(){
+    MergedXmlRpcStruct(){ assertStruct(); }
+    MergedXmlRpcStruct(const XmlRpc::XmlRpcValue& a, const MergedXmlRpcStruct &b, bool recursive= true) :XmlRpc::XmlRpcValue(a){
         assertStruct();
-    }
-    MergedXmlRpcStruct(XmlRpc::XmlRpcValue& a, MergedXmlRpcStruct &b) :XmlRpc::XmlRpcValue(a){
-        assertStruct();
-        _value.asStruct->insert(b._value.asStruct->begin(), b._value.asStruct->end());
+
+        for(ValueStruct::const_iterator it = b._value.asStruct->begin(); it != b._value.asStruct->end(); ++it){
+            std::pair<XmlRpc::XmlRpcValue::iterator,bool> res =  _value.asStruct->insert(*it);
+
+            if(recursive && !res.second && res.first->second.getType() == XmlRpc::XmlRpcValue::TypeStruct && it->second.getType() == XmlRpc::XmlRpcValue::TypeStruct){
+                res.first->second = MergedXmlRpcStruct(res.first->second, it->second); // recursive struct merge with implicit cast
+            }
+        }
+
+
     }
 };
 

--- a/canopen_master/include/canopen_master/objdict.h
+++ b/canopen_master/include/canopen_master/objdict.h
@@ -186,8 +186,8 @@ public:
         return res.second;
     }
     bool iterate(boost::unordered_map<Key, boost::shared_ptr<const Entry> >::const_iterator &it) const;
-    static boost::shared_ptr<ObjectDict> fromFile(const std::string &path);
-    
+    typedef std::list<std::pair<std::string, std::string> > Overlay;
+    static boost::shared_ptr<ObjectDict> fromFile(const std::string &path, const Overlay &overlay = Overlay());
     const DeviceInfo device_info;
     
     ObjectDict(const DeviceInfo &info): device_info(info) {}

--- a/canopen_master/src/objdict.cpp
+++ b/canopen_master/src/objdict.cpp
@@ -245,7 +245,7 @@ void parse_objects(boost::shared_ptr<ObjectDict> dict, boost::property_tree::ptr
         parse_object(dict, pt, name);
     }
 }
-boost::shared_ptr<ObjectDict> ObjectDict::fromFile(const std::string &path){
+boost::shared_ptr<ObjectDict> ObjectDict::fromFile(const std::string &path, const ObjectDict::Overlay &overlay){
     DeviceInfo info;
     boost::property_tree::ptree pt;
     boost::shared_ptr<ObjectDict> dict;
@@ -292,7 +292,11 @@ boost::shared_ptr<ObjectDict> ObjectDict::fromFile(const std::string &path){
     }
 
     dict = boost::make_shared<ObjectDict>(info);
-    
+
+    for(Overlay::const_iterator it= overlay.begin(); it != overlay.end(); ++it){
+        pt.get_child(it->first).put("ParameterValue", it->second);
+    }
+
     parse_objects(dict, pt, "MandatoryObjects");
     parse_objects(dict, pt, "OptionalObjects");
     parse_objects(dict, pt, "ManufacturerObjects");

--- a/canopen_test_utils/config/canopen_rig1.yaml
+++ b/canopen_test_utils/config/canopen_rig1.yaml
@@ -10,5 +10,5 @@ modules:
   - name: rig1_plate_joint
     id: 1
     # vel_unit_factor: 0.01
-
-     
+    dcf_overlay: # "ObjectID": "ParameterValue" (both as strings)
+      "6098": "35" #  homing method

--- a/socketcan_interface/include/socketcan_interface/interface.h
+++ b/socketcan_interface/include/socketcan_interface/interface.h
@@ -11,9 +11,9 @@ namespace can{
 
 /** Header for CAN id an meta data*/
 struct Header{
-    static const unsigned int ERROR_MASK = (1 << 29);
-    static const unsigned int RTR_MASK = (1 << 30);
-    static const unsigned int EXTENDED_MASK = (1 << 31);
+    static const unsigned int ERROR_MASK = (1u << 29);
+    static const unsigned int RTR_MASK = (1u << 30);
+    static const unsigned int EXTENDED_MASK = (1u << 31);
     
     unsigned int id:29; ///< CAN ID (11 or 29 bits valid, depending on is_extended member
     unsigned int is_error:1; ///< marks an error frame (only used internally)


### PR DESCRIPTION
Overlay DCF parameters with settings from ROS parameter server, example given in canopen_test_utils/config/canopen_rig1.yaml
Needed for https://github.com/ipa320/cob_robots/pull/269
