### PR TITLE
Move ip_mode_sub_mode to configureModeSpecificEntries

### DIFF
--- a/canopen_402/src/canopen_402/canopen_402.cpp
+++ b/canopen_402/src/canopen_402/canopen_402.cpp
@@ -684,8 +684,6 @@ void Node_402::configureEntries()
   n_->getStorage()->entry(op_mode_display, 0x6061);
   n_->getStorage()->entry(supported_drive_modes, 0x6502);
 
-  n_->getStorage()->entry(ip_mode_sub_mode, 0x60C0);
-
   n_->getStorage()->entry(actual_vel, 0x606C);
 
   n_->getStorage()->entry(actual_pos, 0x6064);
@@ -704,6 +702,7 @@ void Node_402::configureModeSpecificEntries()
   }
   if (isModeSupported(Interpolated_Position))
   {
+	n_->getStorage()->entry(ip_mode_sub_mode, 0x60C0);
     n_->getStorage()->entry(target_interpolated_position, 0x60C1, 0x01);
     if (ip_mode_sub_mode.get_cached() == -1)
       n_->getStorage()->entry(target_interpolated_velocity, 0x60C1, 0x02);

--- a/canopen_402/src/canopen_402/canopen_402.cpp
+++ b/canopen_402/src/canopen_402/canopen_402.cpp
@@ -702,7 +702,7 @@ void Node_402::configureModeSpecificEntries()
   }
   if (isModeSupported(Interpolated_Position))
   {
-	n_->getStorage()->entry(ip_mode_sub_mode, 0x60C0);
+    n_->getStorage()->entry(ip_mode_sub_mode, 0x60C0);
     n_->getStorage()->entry(target_interpolated_position, 0x60C1, 0x01);
     if (ip_mode_sub_mode.get_cached() == -1)
       n_->getStorage()->entry(target_interpolated_velocity, 0x60C1, 0x02);


### PR DESCRIPTION
The ip_mode_sub_mode entry is specific to interpolated position mode.

The previous implementation breaks compatiblility to devices, which do not support ip mode.
