### PR TITLE
Added generic object publisher

### DIFF
--- a/canopen_chain_node/CMakeLists.txt
+++ b/canopen_chain_node/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   diagnostic_updater
   pluginlib
   socketcan_interface
+  std_msgs
 )
 
 ## System dependencies are found with CMake's conventions
@@ -86,7 +87,7 @@ find_package(Boost REQUIRED COMPONENTS filesystem)
 catkin_package(
   INCLUDE_DIRS include
 #  LIBRARIES canopen_chain_node
-  CATKIN_DEPENDS canopen_master roslib roscpp cob_srvs diagnostic_updater pluginlib socketcan_interface
+  CATKIN_DEPENDS canopen_master roslib roscpp cob_srvs diagnostic_updater pluginlib socketcan_interface std_msgs
 #  DEPENDS system_lib
 )
 

--- a/canopen_chain_node/package.xml
+++ b/canopen_chain_node/package.xml
@@ -19,6 +19,7 @@
   <depend>diagnostic_updater</depend>
   <depend>pluginlib</depend>
   <depend>socketcan_interface</depend> <!-- direct dependency needed for pluginlib look-up -->
+  <depend>std_msgs</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/canopen_master/include/canopen_master/objdict.h
+++ b/canopen_master/include/canopen_master/objdict.h
@@ -114,14 +114,17 @@ class ObjectDict{
 protected:
 public:
     class Key{
+        static size_t fromString(const std::string &str);
     public:
         const size_t hash;
         Key(const uint16_t i) : hash((i<<16)| 0xFFFF) {}
         Key(const uint16_t i, const uint8_t s): hash((i<<16)| s) {}
+        Key(const std::string &str): hash(fromString(str)) {}
         bool hasSub() const { return (hash & 0xFFFF) != 0xFFFF; }
         uint8_t sub_index() const { return hash & 0xFFFF; }
         uint16_t index() const { return hash  >> 16;}
         bool operator==(const Key &other) const { return hash == other.hash; }
+        operator std::string() const;
     };
     enum Code{
         NULL_DATA = 0x00,

--- a/canopen_master/src/objdict.cpp
+++ b/canopen_master/src/objdict.cpp
@@ -28,6 +28,18 @@ template<> String & ObjectStorage::Data::allocate(){
     return buffer;
 }
 
+size_t ObjectDict::Key::fromString(const std::string &str){
+    uint16_t index = 0;
+    uint8_t sub_index = 0;
+    int num = sscanf(str.c_str(),"%hxsub%hhx", &index, &sub_index);
+    return (index << 16) | (num==2?sub_index:0xFFFF);
+}
+ObjectDict::Key::operator std::string() const{
+    std::stringstream sstr;
+    sstr << std::hex << index();
+    if(hasSub()) sstr << 'sub' << (int) sub_index();
+    return sstr.str();
+}
 void ObjectStorage::Data::init(){
     boost::mutex::scoped_lock lock(mutex);
 

--- a/canopen_test_utils/config/canopen_rig12.yaml
+++ b/canopen_test_utils/config/canopen_rig12.yaml
@@ -1,6 +1,7 @@
 defaults:
   eds_pkg: canopen_test_utils
   eds_file: "config/Elmo.dcf"
+  publish: ["60C1sub1"]
   dcf_overlay: # "ObjectID": "ParameterValue" (both as strings)
     "6098": "35" #  homing method
     "1016sub1" : "0x7F0064" # heartbeat timeout of 100 ms for master at 127
@@ -9,5 +10,6 @@ defaults:
 nodes:
   rig1_plate_joint:
     id: 1
+    publish: ["6060"]
   rig2_plate_joint:
     id: 85


### PR DESCRIPTION
Publish any CANopen object as a single ROS topic with sync rate.

Example config for rig12 spawns:
- /rig12/rig1_plate_joint_6060 (std_msgs/Int8): mode command for module 1
- /rig12/rig2_plate_joint_60C1sub1 (std_msgs/Int32): IP command for module 2
