### PR TITLE
Flexible input/output mapping/calculation

### DIFF
--- a/canopen_chain_node/CMakeLists.txt
+++ b/canopen_chain_node/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   diagnostic_updater
   pluginlib
   socketcan_interface
+  std_msgs
 )
 
 ## System dependencies are found with CMake's conventions
@@ -86,7 +87,7 @@ find_package(Boost REQUIRED COMPONENTS filesystem)
 catkin_package(
   INCLUDE_DIRS include
 #  LIBRARIES canopen_chain_node
-  CATKIN_DEPENDS canopen_master roslib roscpp cob_srvs diagnostic_updater pluginlib socketcan_interface
+  CATKIN_DEPENDS canopen_master roslib roscpp cob_srvs diagnostic_updater pluginlib socketcan_interface std_msgs
 #  DEPENDS system_lib
 )
 

--- a/canopen_chain_node/include/canopen_chain_node/chain_ros.h
+++ b/canopen_chain_node/include/canopen_chain_node/chain_ros.h
@@ -57,19 +57,18 @@ public:
         }
     }
 private:
-    template <typename Tpub, typename Tobj> static void publish_cached(ros::Publisher &pub, ObjectStorage::Entry<Tobj> &entry){
-        pub.publish<typename Tpub::_data_type>(entry.get_cached());
-    }
-    template <typename Tpub, typename Tobj> static void publish(ros::Publisher &pub, ObjectStorage::Entry<Tobj> &entry){
-        pub.publish<typename Tpub::_data_type>(entry.get());
+    template <typename Tpub, typename Tobj, bool forced> static void publish(ros::Publisher &pub, ObjectStorage::Entry<Tobj> &entry){
+		Tpub msg;
+		msg.data = (const typename Tpub::_data_type &)(forced? entry.get() : entry.get_cached());
+        pub.publish(msg);
     }
     template<typename Tpub, typename Tobj> static func_type create(ros::NodeHandle &nh,  const std::string &name, ObjectStorage::Entry<Tobj> entry, bool force){
         if(!entry.valid()) return 0;
         ros::Publisher pub = nh.advertise<Tpub>(name, 1);
         if(force){
-            return boost::bind(PublishFunc::publish<Tpub, Tobj>, pub, entry);
+            return boost::bind(PublishFunc::publish<Tpub, Tobj, true>, pub, entry);
         }else{
-            return boost::bind(PublishFunc::publish_cached<Tpub, Tobj>, pub, entry);
+            return boost::bind(PublishFunc::publish<Tpub, Tobj, false>, pub, entry);
         }
     }
 };

--- a/canopen_chain_node/package.xml
+++ b/canopen_chain_node/package.xml
@@ -19,6 +19,7 @@
   <depend>diagnostic_updater</depend>
   <depend>pluginlib</depend>
   <depend>socketcan_interface</depend> <!-- direct dependency needed for pluginlib look-up -->
+  <depend>std_msgs</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/canopen_master/CMakeLists.txt
+++ b/canopen_master/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 ## System dependencies are found with CMake's conventions
-find_package(Boost REQUIRED COMPONENTS chrono)
+find_package(Boost REQUIRED COMPONENTS chrono atomic)
 
 
 ###################################

--- a/canopen_master/include/canopen_master/canopen.h
+++ b/canopen_master/include/canopen_master/canopen.h
@@ -35,6 +35,7 @@ class SDOClient{
     boost::timed_mutex mutex;
     boost::mutex cond_mutex;
     boost::condition_variable cond;
+    boost::mutex buffer_mutex;
     bool success;
     
     void handleFrame(const can::Frame & msg);

--- a/canopen_master/include/canopen_master/canopen.h
+++ b/canopen_master/include/canopen_master/canopen.h
@@ -16,6 +16,7 @@ namespace canopen{
 typedef boost::chrono::high_resolution_clock::time_point time_point;
 typedef boost::chrono::high_resolution_clock::duration time_duration;
 inline time_point get_abs_time(const time_duration& timeout) { return boost::chrono::high_resolution_clock::now() + timeout; }
+inline time_point get_abs_time() { return boost::chrono::high_resolution_clock::now(); }
 
 
     

--- a/canopen_master/include/canopen_master/layer.h
+++ b/canopen_master/include/canopen_master/layer.h
@@ -2,6 +2,7 @@
 #define H_CANOPEN_LAYER
 
 #include <vector>
+#include <boost/thread/shared_mutex.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/atomic.hpp>
 
@@ -138,6 +139,7 @@ private:
 template<typename T> class VectorHelper{
     typedef std::vector<boost::shared_ptr<T> > vector_type ;
     vector_type layers;
+    boost::shared_mutex mutex;
 
     template<typename Bound, typename Iterator, typename Data> Iterator call(void(Layer::*func)(Data&), Data &status, const Iterator &begin, const Iterator &end){
         bool okay_on_start = status.template bounded<Bound>();
@@ -155,20 +157,24 @@ template<typename T> class VectorHelper{
     }
 protected:
     template<typename Bound, typename Data> typename vector_type::iterator call(void(Layer::*func)(Data&), Data &status){
+        boost::shared_lock<boost::shared_mutex> lock(mutex);
         return call<Bound>(func, status, layers.begin(), layers.end());
     }
     template<typename Data> typename vector_type::iterator call(void(Layer::*func)(Data&), Data &status){
+        boost::shared_lock<boost::shared_mutex> lock(mutex);
         return call<LayerStatus::Unbounded>(func, status, layers.begin(), layers.end());
     }
     template<typename Bound, typename Data> typename vector_type::reverse_iterator call_rev(void(Layer::*func)(Data&), Data &status){
+        boost::shared_lock<boost::shared_mutex> lock(mutex);
         return call<Bound>(func, status, layers.rbegin(), layers.rend());
     }
     template<typename Data> typename vector_type::reverse_iterator call_rev(void(Layer::*func)(Data&), Data &status){
+        boost::shared_lock<boost::shared_mutex> lock(mutex);
         return call<LayerStatus::Unbounded>(func, status, layers.rbegin(), layers.rend());
     }
-    void destroy() { layers.clear(); }
+    void destroy() { boost::unique_lock<boost::shared_mutex> lock(mutex); layers.clear(); }
 public:
-    virtual void add(const boost::shared_ptr<T> &l) { layers.push_back(l); }
+    virtual void add(const boost::shared_ptr<T> &l) { boost::unique_lock<boost::shared_mutex> lock(mutex); layers.push_back(l); }
 };
 
 template<typename T=Layer> class LayerGroup : public Layer, public VectorHelper<T> {

--- a/canopen_master/include/canopen_master/layer.h
+++ b/canopen_master/include/canopen_master/layer.h
@@ -132,7 +132,7 @@ protected:
     virtual void handleRecover(LayerStatus &status)  = 0;
 
 private:
-    LayerState state;
+    boost::atomic<LayerState> state;
 
 };
 

--- a/canopen_master/include/canopen_master/objdict.h
+++ b/canopen_master/include/canopen_master/objdict.h
@@ -114,14 +114,17 @@ class ObjectDict{
 protected:
 public:
     class Key{
+        static size_t fromString(const std::string &str);
     public:
         const size_t hash;
         Key(const uint16_t i) : hash((i<<16)| 0xFFFF) {}
         Key(const uint16_t i, const uint8_t s): hash((i<<16)| s) {}
+        Key(const std::string &str): hash(fromString(str)) {}
         bool hasSub() const { return (hash & 0xFFFF) != 0xFFFF; }
         uint8_t sub_index() const { return hash & 0xFFFF; }
         uint16_t index() const { return hash  >> 16;}
         bool operator==(const Key &other) const { return hash == other.hash; }
+        operator std::string() const;
     };
     enum Code{
         NULL_DATA = 0x00,

--- a/canopen_master/src/node.cpp
+++ b/canopen_master/src/node.cpp
@@ -211,8 +211,8 @@ void Node::handleRecover(LayerStatus &status){
     }
 }
 void Node::handleShutdown(LayerStatus &status){
-    if(getHeartbeatInterval()> 0) heartbeat_.set(0);
     stop();
+    if(getHeartbeatInterval()> 0) heartbeat_.set(0);
     nmt_listener_.reset();
     switchState(Unknown);
 }

--- a/canopen_master/src/node.cpp
+++ b/canopen_master/src/node.cpp
@@ -57,7 +57,6 @@ bool Node::reset(){
     getStorage()->reset();
     
     interface_->send(NMTcommand::Frame(node_id_, NMTcommand::Reset));
-    interface_->send(NMTcommand::Frame(node_id_, NMTcommand::Reset_Com));
     if(wait_for(BootUp, boost::chrono::seconds(10)) != 1){
         return false;
     }

--- a/canopen_master/src/objdict.cpp
+++ b/canopen_master/src/objdict.cpp
@@ -37,7 +37,7 @@ size_t ObjectDict::Key::fromString(const std::string &str){
 ObjectDict::Key::operator std::string() const{
     std::stringstream sstr;
     sstr << std::hex << index();
-    if(hasSub()) sstr << 'sub' << (int) sub_index();
+    if(hasSub()) sstr << "sub" << (int) sub_index();
     return sstr.str();
 }
 void ObjectStorage::Data::init(){

--- a/canopen_master/src/objdict.cpp
+++ b/canopen_master/src/objdict.cpp
@@ -28,6 +28,18 @@ template<> String & ObjectStorage::Data::allocate(){
     return buffer;
 }
 
+size_t ObjectDict::Key::fromString(const std::string &str){
+    uint16_t index = 0;
+    uint8_t sub_index = 0;
+    int num = sscanf(str.c_str(),"%hxsub%hhx", &index, &sub_index);
+    return (index << 16) | (num==2?sub_index:0xFFFF);
+}
+ObjectDict::Key::operator std::string() const{
+    std::stringstream sstr;
+    sstr << std::hex << index();
+    if(hasSub()) sstr << 'sub' << (int) sub_index();
+    return sstr.str();
+}
 void ObjectStorage::Data::init(){
     boost::mutex::scoped_lock lock(mutex);
 

--- a/canopen_motor_node/CMakeLists.txt
+++ b/canopen_motor_node/CMakeLists.txt
@@ -17,6 +17,8 @@ find_package(catkin REQUIRED COMPONENTS
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 
+find_package(PkgConfig)
+pkg_check_modules (MUPARSER REQUIRED muparser)
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
@@ -99,6 +101,7 @@ catkin_package(
 # include_directories(include)
 include_directories(
   ${catkin_INCLUDE_DIRS}
+  ${MUPARSER_INCLUDE_DIRS}
 )
 
 ## Declare a cpp library
@@ -116,6 +119,7 @@ add_executable(canopen_motor_node src/control_node.cpp)
 ## Specify libraries to link a library or executable target against
 target_link_libraries(canopen_motor_node
   ${catkin_LIBRARIES}
+  ${MUPARSER_LIBRARIES}
 )
 
 #############

--- a/canopen_motor_node/package.xml
+++ b/canopen_motor_node/package.xml
@@ -18,6 +18,7 @@
   <depend>joint_limits_interface</depend>
   <depend>canopen_402</depend>
   <depend>urdf</depend>
+  <depend>muparser</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/canopen_motor_node/src/control_node.cpp
+++ b/canopen_motor_node/src/control_node.cpp
@@ -26,7 +26,9 @@ class UnitConverter{
 public:
     typedef boost::function<double * (const std::string &) > get_var_func_type;
 
-    UnitConverter(const std::string &expression, get_var_func_type var_func = get_var_func_type()){
+    UnitConverter(const std::string &expression, get_var_func_type var_func = get_var_func_type())
+    : var_func_(var_func)
+    {
         parser_.SetVarFactory(UnitConverter::createVariable, this);
 
         parser_.DefineConst("pi", M_PI);

--- a/canopen_motor_node/src/control_node.cpp
+++ b/canopen_motor_node/src/control_node.cpp
@@ -192,7 +192,7 @@ public:
     : Layer(name + " Handle"), motor_(motor), variables_(storage), jsh_(name, &pos_, &vel_, &eff_), jph_(jsh_, &cmd_pos_), jvh_(jsh_, &cmd_vel_), jeh_(jsh_, &cmd_eff_), jh_(0) {
        commands_[No_Mode] = 0;
 
-       std::string p2d("rint(rad2deg(pos)*1000"), v2d("rint(rad2deg(vel)*1000"), e2d("rint(eff)");
+       std::string p2d("rint(rad2deg(pos)*1000)"), v2d("rint(rad2deg(vel)*1000)"), e2d("rint(eff)");
        std::string p2r("deg2rad(obj6064)/1000"), v2r("deg2rad(obj606C)/1000"), e2r("0");
 
        if(options.hasMember("pos_to_device")) p2d = (const std::string&) options["pos_to_device"];

--- a/canopen_motor_node/src/control_node.cpp
+++ b/canopen_motor_node/src/control_node.cpp
@@ -53,7 +53,8 @@ class HandleLayer: public Layer{
 
     
     hardware_interface::JointStateHandle jsh_;
-    hardware_interface::JointHandle jph_, jvh_, jeh_, *jh_;
+    hardware_interface::JointHandle jph_, jvh_, jeh_;
+    boost::atomic<hardware_interface::JointHandle*> jh_;
 
     typedef boost::unordered_map< OperationMode,hardware_interface::JointHandle* > CommandMap;
     CommandMap commands_;

--- a/canopen_motor_node/src/control_node.cpp
+++ b/canopen_motor_node/src/control_node.cpp
@@ -82,9 +82,12 @@ class HandleLayer: public Layer{
     }
 public:
     HandleLayer(const std::string &name, const boost::shared_ptr<MotorNode> & motor)
-    : Layer(name + " Handle"), motor_(motor), jsh_(name, &pos_, &vel_, &eff_), jph_(jsh_, &cmd_pos_), jvh_(jsh_, &cmd_vel_), jeh_(jsh_, &cmd_eff_), jh_(0) {}
+    : Layer(name + " Handle"), motor_(motor), jsh_(name, &pos_, &vel_, &eff_), jph_(jsh_, &cmd_pos_), jvh_(jsh_, &cmd_vel_), jeh_(jsh_, &cmd_eff_), jh_(0) {
+        commands_[No_Mode] = 0;
+    }
 
     int canSwitch(const OperationMode &m){
+       if(!motor_->isModeSupported(m)) return 0;
        if(motor_->getMode() == m) return -1;
        if(commands_.find(m) != commands_.end()) return 1;
        return 0;

--- a/canopen_motor_node/src/control_node.cpp
+++ b/canopen_motor_node/src/control_node.cpp
@@ -195,6 +195,12 @@ public:
        std::string p2d("rint(rad2deg(pos)*1000)"), v2d("rint(rad2deg(vel)*1000)"), e2d("rint(eff)");
        std::string p2r("deg2rad(obj6064)/1000"), v2r("deg2rad(obj606C)/1000"), e2r("0");
 
+       if(options.hasMember("pos_unit_factor") || options.hasMember("vel_unit_factor") || options.hasMember("eff_unit_factor")){
+           const std::string reason("*_unit_factor parameters are not supported anymore, please migrate to conversion functions.");
+           ROS_FATAL_STREAM(reason);
+           throw std::invalid_argument(reason);
+       }
+
        if(options.hasMember("pos_to_device")) p2d = (const std::string&) options["pos_to_device"];
        if(options.hasMember("pos_from_device")) p2r = (const std::string&) options["pos_from_device"];
 

--- a/canopen_test_utils/config/Elmo.dcf
+++ b/canopen_test_utils/config/Elmo.dcf
@@ -1300,7 +1300,7 @@ AccessType=rw
 PDOMapping=0
 LowLimit=0
 HighLimit=8
-ParameterValue=2
+ParameterValue=3
 
 [1A00sub1]
 ParameterName=Status Word
@@ -1327,6 +1327,7 @@ ObjectType=0x7
 DataType=0x0007
 AccessType=rw
 PDOMapping=0
+ParameterValue=0x20410020
 
 [1A00sub4]
 ParameterName=PDO Mapping Entry_4

--- a/canopen_test_utils/config/canopen_rig12.yaml
+++ b/canopen_test_utils/config/canopen_rig12.yaml
@@ -1,6 +1,7 @@
 defaults:
   eds_pkg: canopen_test_utils
   eds_file: "config/Elmo.dcf"
+  publish: ["60C1sub1"]
   dcf_overlay: # "ObjectID": "ParameterValue" (both as strings)
     "6098": "35" #  homing method
     "1016sub1" : "0x7F0064" # heartbeat timeout of 100 ms for master at 127
@@ -9,5 +10,6 @@ defaults:
 nodes:
   rig1_plate_joint:
     id: 1
+    publish: ["6060"]
   rig2_plate_joint:
     id: 85

--- a/canopen_test_utils/scripts/elmo_mapping.py
+++ b/canopen_test_utils/scripts/elmo_mapping.py
@@ -5,7 +5,7 @@ PDOs={
 "RPDO3": [1, ('607A',     "target_position",              4), ('60FF',     "target_profiled_velocity",     4)],
 "RPDO4": [1, ('60C1sub1', "target_interpolated_position", 4)],
 
-"TPDO1": [1, ('6041',     "status_word",                  2), ('6061',     "op_mode_display",              1)],
+"TPDO1": [1, ('6041',     "status_word",                  2), ('6061',     "op_mode_display",              1), ('2041',     "timestamp",     4)],
 "TPDO3": [1, ('6064',     "actual_position",              4), ('606C',     "actual_velocity",              4)],
 }
 

--- a/socketcan_interface/include/socketcan_interface/asio_base.h
+++ b/socketcan_interface/include/socketcan_interface/asio_base.h
@@ -23,6 +23,7 @@ template<typename Socket> class AsioDriver : public DriverInterface{
     
 protected:
     boost::asio::io_service io_service_;
+    boost::asio::strand strand_;
     Socket socket_;
     Frame input_;
     
@@ -30,7 +31,7 @@ protected:
     virtual bool enqueue(const Frame & msg) = 0;
     
     void dispatchFrame(const Frame &msg){
-        io_service_.post(boost::bind(&FrameDispatcher::dispatch, &frame_dispatcher_, msg)); // copies msg
+        strand_.post(boost::bind(&FrameDispatcher::dispatch, &frame_dispatcher_, msg)); // copies msg
     }
     void setErrorCode(const boost::system::error_code& error){
         boost::mutex::scoped_lock lock(state_mutex_);
@@ -65,7 +66,7 @@ protected:
     }
 
     AsioDriver()
-    : socket_(io_service_)
+    : strand_(io_service_), socket_(io_service_)
     {}
 
 public:

--- a/socketcan_interface/include/socketcan_interface/socketcan.h
+++ b/socketcan_interface/include/socketcan_interface/socketcan.h
@@ -82,7 +82,7 @@ public:
                 }
             }
             
-            struct sockaddr_can addr;
+            struct sockaddr_can addr = {0};
             addr.can_family = AF_CAN;
             addr.can_ifindex = ifr.ifr_ifindex;
             ret = bind( sc, (struct sockaddr*)&addr, sizeof(addr) );            
@@ -164,7 +164,7 @@ protected:
     virtual bool enqueue(const Frame & msg){
         boost::mutex::scoped_lock lock(send_mutex_); //TODO: timed try lock
 
-        can_frame frame;
+        can_frame frame = {0};
         frame.can_id = msg.id | (msg.is_extended?CAN_EFF_FLAG:0) | (msg.is_rtr?CAN_RTR_FLAG:0);;
         frame.can_dlc = msg.dlc;
         


### PR DESCRIPTION
Replaced pos_unit_factor, vel_unit_factor and eff_unit_factor by *_to_device and *_from_device.
Based on [muparser](http://muparser.beltoforion.de/) arbitrary formulas can be used to convert units.
Beside the [built-in function and operators](http://muparser.beltoforion.de/mup_features.html#idDef1) it supports:
- pi: constant
- nan: constant
- rad2deg(radians): convert radians to degrees
- deg2rad(degrees): convert degrees to radians
- norm(value, min, max): normalize value to the range [min, max)
- smooth(value, old_value, alpha): exponential smooting
- avg(value, ...): average of all provided arguments, stop on first nan value

The *_to_device strings have the respective ros_control inputs avaiable: pos, vel and eff
The *_from_device uses special CANopen object variables like obj6064 () (actual position) or obj6091sub1 (motor revolutions).
Per defaults positions and velecities are converted between radians and milli degrees, efforts are set to 0.

This PR includes #85,#89 and #91.
