### PR TITLE
Added validity check to heartbeat_

### DIFF
--- a/canopen_master/include/canopen_master/canopen.h
+++ b/canopen_master/include/canopen_master/canopen.h
@@ -238,7 +238,7 @@ private:
     PDOMapper pdo_;
 
     boost::chrono::high_resolution_clock::time_point heartbeat_timeout_;
-    double getHeartbeatInterval() { return heartbeat_.valid()?heartbeat_.get_cached() : 0; }
+    uint16_t getHeartbeatInterval() { return heartbeat_.valid()?heartbeat_.get_cached() : 0; }
     void setHeartbeatInterval() { if(heartbeat_.valid()) heartbeat_.set(heartbeat_.desc().value().get<uint16_t>()); }
     bool checkHeartbeat();
 };

--- a/canopen_master/src/node.cpp
+++ b/canopen_master/src/node.cpp
@@ -110,8 +110,9 @@ void Node::switchState(const uint8_t &s){
 }
 void Node::handleNMT(const can::Frame & msg){
     boost::mutex::scoped_lock cond_lock(cond_mutex);
-    if (heartbeat_.valid())
-      heartbeat_timeout_ = boost::chrono::high_resolution_clock::now() + boost::chrono::milliseconds(3*heartbeat_.get_cached());
+    uint16_t interval = getHeartbeatInterval();
+    if (interval != 0)
+      heartbeat_timeout_ = boost::chrono::high_resolution_clock::now() + boost::chrono::milliseconds(3*interval);
     assert(msg.dlc == 1);
     switchState(msg.data[0]);
     cond_lock.unlock();
@@ -138,7 +139,7 @@ template<typename T> int Node::wait_for(const State &s, const T &timeout){
     return 1;
 }
 bool Node::checkHeartbeat(){
-    if(!heartbeat_.valid() || !heartbeat_.get_cached()) return true; //disabled
+    if(getHeartbeatInterval() == 0) return true; //disabled
     boost::mutex::scoped_lock cond_lock(cond_mutex);
     return heartbeat_timeout_ >= boost::chrono::high_resolution_clock::now();
 }

--- a/canopen_master/src/node.cpp
+++ b/canopen_master/src/node.cpp
@@ -214,7 +214,7 @@ void Node::handleRecover(LayerStatus &status){
 }
 void Node::handleShutdown(LayerStatus &status){
     stop();
-    if(heartbeat_.valid() && getHeartbeatInterval()> 0) heartbeat_.set(0);
+    if(getHeartbeatInterval()> 0) heartbeat_.set(0);
     nmt_listener_.reset();
     switchState(Unknown);
 }


### PR DESCRIPTION
When using devices, which do not support heartbeat, the old implementation throws InvalidPointer exceptions.

CANOPEN 301, p. 75:
"The implementation of either guarding or heartbeat is mandatory."

Thus those device are standard compliant and should be supported.
