### PR TITLE
removed unstable StateWaiter::wait_for

### DIFF
--- a/canopen_master/include/canopen_master/can_layer.h
+++ b/canopen_master/include/canopen_master/can_layer.h
@@ -68,10 +68,12 @@ public:
         } else if(!driver_->init(device_, loopback_)) {
             status.error("CAN init failed");
         } else {
+            can::StateWaiter waiter(driver_.get());
+
             thread_.reset(new boost::thread(&can::DriverInterface::run, driver_));
             error_listener_ = driver_->createMsgListener(can::ErrorHeader(), can::CommInterface::FrameDelegate(this, &CANLayer::handleFrame));
 	    
-	    if(!can::StateWaiter::wait_for(can::State::ready, driver_.get(), boost::posix_time::seconds(1))){
+	    if(!waiter.wait(can::State::ready, boost::posix_time::seconds(1))){
 		status.error("CAN init timed out");
 	    }
         }

--- a/socketcan_interface/include/socketcan_interface/threading.h
+++ b/socketcan_interface/include/socketcan_interface/threading.h
@@ -36,10 +36,6 @@ public:
         }
         return true;
     }
-    template<typename InterfaceType, typename DurationType> static bool wait_for(const can::State::DriverState &s, InterfaceType *interface, const DurationType &duration){
-        StateWaiter waiter(interface);
-        return waiter.wait(s,duration);
-    }
 };
 
 template<typename WrappedInterface> class ThreadedInterface : public WrappedInterface{
@@ -50,8 +46,9 @@ template<typename WrappedInterface> class ThreadedInterface : public WrappedInte
 public:
     virtual bool init(const std::string &device, bool loopback) {
         if(!thread_ && WrappedInterface::init(device, loopback)){
+            StateWaiter waiter(this);
             thread_.reset(new boost::thread(&ThreadedInterface::run_thread, this));
-            return StateWaiter::wait_for(can::State::ready, this, boost::posix_time::seconds(1));
+            return waiter.wait(can::State::ready, boost::posix_time::seconds(1));
         }
         return WrappedInterface::getState().isReady();
     }


### PR DESCRIPTION
CAN init failed spuriously for no reason.
It turns out that StateWaiter::wait_for had a race condition with the driver thread.
So it was removed in favour of the explicit wait() call on a dedicated waiter instance.
