### PR TITLE
Fix for pluginlib-related crashes on shutdown

### DIFF
--- a/canopen_chain_node/include/canopen_chain_node/chain_ros.h
+++ b/canopen_chain_node/include/canopen_chain_node/chain_ros.h
@@ -654,7 +654,6 @@ public:
             halt(s);
             shutdown(s);
         }catch(...){ LOG("CATCH"); }
-        destroy();
     }
 };
 

--- a/canopen_master/include/canopen_master/canopen.h
+++ b/canopen_master/include/canopen_master/canopen.h
@@ -173,6 +173,7 @@ public:
     SyncCounter(const SyncProperties &p) : properties(p) {}
     virtual void addNode(void * const ptr)  = 0;
     virtual  void removeNode(void * const ptr) = 0;
+    virtual ~SyncCounter() {}
 };
 
 class Node : public Layer{

--- a/canopen_master/include/canopen_master/timer.h
+++ b/canopen_master/include/canopen_master/timer.h
@@ -36,6 +36,10 @@ public:
         boost::mutex::scoped_lock lock(mutex);
         return period;
     }
+    ~Timer(){
+        io.stop();
+        thread.join();
+    }
     
 private:
     boost::asio::io_service io;

--- a/canopen_master/src/node.cpp
+++ b/canopen_master/src/node.cpp
@@ -88,7 +88,7 @@ bool Node::stop(){
         // ERROR
     }
     interface_->send(NMTcommand::Frame(node_id_, NMTcommand::Stop));
-    return 0 != wait_for(Stopped, boost::chrono::seconds(2));
+    return true;
 }
 
 void Node::switchState(const uint8_t &s){
@@ -212,8 +212,8 @@ void Node::handleRecover(LayerStatus &status){
     }
 }
 void Node::handleShutdown(LayerStatus &status){
-    stop();
     if(getHeartbeatInterval()> 0) heartbeat_.set(0);
+    stop();
     nmt_listener_.reset();
     switchState(Unknown);
 }


### PR DESCRIPTION
Since the introduction of the motor layer plugins (dbbc2281458886578250a6514d5ea8bbd1d8b160) the driver crashed silently on shutdown (ctrl+c). However, it was listed in dmesg.

It turns out that the class loader went out scope while motor instances were still be used elsewhere.
This fix introduces a guarded variant of the class loader that keeps the class loader alive until the chain instance was deleted.

closes #107 
