### PR TITLE
Verbose exceptions, fix for #110

### DIFF
--- a/canopen_master/include/canopen_master/exceptions.h
+++ b/canopen_master/include/canopen_master/exceptions.h
@@ -7,14 +7,24 @@
 
 namespace canopen{
 
-class Exception : public std::exception {};
-
-class PointerInvalid : public Exception{};
-class ParseException : public Exception{};
-
-class TimeoutException : public std::runtime_error{
+class Exception : public std::runtime_error {
 public:
-    TimeoutException(const std::string &w) : std::runtime_error(w) {}
+    Exception(const std::string &w) : std::runtime_error(w) {}
+};
+
+class PointerInvalid : public Exception{
+public:
+    PointerInvalid(const std::string &w) : Exception("Pointer invalid") {}
+};
+
+class ParseException : public Exception{
+public:
+    ParseException(const std::string &w) : Exception(w) {}
+};
+
+class TimeoutException : public Exception{
+public:
+    TimeoutException(const std::string &w) : Exception(w) {}
 };
 
 

--- a/canopen_master/include/canopen_master/objdict.h
+++ b/canopen_master/include/canopen_master/objdict.h
@@ -250,9 +250,8 @@ template<typename T> std::ostream& operator<<(std::ostream& stream, const NodeId
  }
 
 class AccessException : public Exception{
-    const ObjectDict::Key k_;
 public:
-    AccessException(const ObjectDict::Key &k) : k_(k) {}
+    AccessException(const std::string &w) : Exception(w) {}
 };
  
  
@@ -313,7 +312,7 @@ protected:
             boost::mutex::scoped_lock lock(mutex);
             
             if(!entry->readable){
-                BOOST_THROW_EXCEPTION( AccessException(key) );
+                BOOST_THROW_EXCEPTION( AccessException(std::string(key) + " is not readable") );
             }
             
             if(entry->constant) cached = true;
@@ -329,7 +328,7 @@ protected:
             
             if(!entry->writable){
                 if(access<T>() != val){
-                    BOOST_THROW_EXCEPTION( AccessException(key) );
+                    BOOST_THROW_EXCEPTION( AccessException(std::string(key) + " is not readable") );
                 }
             }else{
                 allocate<T>() = val;
@@ -340,7 +339,7 @@ protected:
             boost::mutex::scoped_lock lock(mutex);
             if(!valid || val != access<T>() ){
                 if(!entry->writable){
-                        BOOST_THROW_EXCEPTION( AccessException(key) );
+                    BOOST_THROW_EXCEPTION( AccessException(std::string(key) + " is neither cached nor  writable") );
                 }else{
                     allocate<T>() = val;
                     write_delegate(*entry, buffer);
@@ -364,7 +363,7 @@ public:
         typedef T type;
         bool valid() const { return data != 0; }
         const T get() {
-            if(!data) BOOST_THROW_EXCEPTION( PointerInvalid() );
+            if(!data) BOOST_THROW_EXCEPTION( PointerInvalid("ObjectStorage::Entry::get()") );
 
             return data->get<T>(false);
         }    
@@ -377,7 +376,7 @@ public:
             }
         }    
         const T get_cached() {
-            if(!data) BOOST_THROW_EXCEPTION( PointerInvalid() );
+            if(!data) BOOST_THROW_EXCEPTION( PointerInvalid("ObjectStorage::Entry::get_cached()") );
 
             return data->get<T>(true);
         }        
@@ -390,7 +389,7 @@ public:
             }
         }    
         void set(const T &val) {
-            if(!data) BOOST_THROW_EXCEPTION( PointerInvalid() );
+            if(!data) BOOST_THROW_EXCEPTION( PointerInvalid("ObjectStorage::Entry::set(val)") );
             data->set(val);
         }
         bool set_cached(const T &val) {

--- a/canopen_master/src/objdict.cpp
+++ b/canopen_master/src/objdict.cpp
@@ -104,7 +104,7 @@ void set_access( ObjectDict::Entry &entry, const std::string &access){
         entry.writable = false;
         entry.constant = true;
     }else{
-        throw ParseException();
+        throw ParseException("Cannot determine access for" + std::string(ObjectDict::Key(entry)));
     }
 }
 
@@ -246,7 +246,7 @@ void parse_object(boost::shared_ptr<ObjectDict> dict, boost::property_tree::iptr
                 }
             }
         }else{
-            throw ParseException();
+            throw ParseException("ObjectType of " + entry->desc + " not supported") ;
         }
 }
 void parse_objects(boost::shared_ptr<ObjectDict> dict, boost::property_tree::iptree &pt, const std::string &key){


### PR DESCRIPTION
As discussed in #110 the exception handling in the service was missing some cases.
In addition all canopen::Exception are verbose now (#64).
