### PR TITLE
Set initialized_ earlier, because shutdown might fail.

### DIFF
--- a/canopen_chain_node/include/canopen_chain_node/chain_ros.h
+++ b/canopen_chain_node/include/canopen_chain_node/chain_ros.h
@@ -280,9 +280,9 @@ protected:
         }
 
         res.success = false;
+        initialized_ = false;
         shutdown(status);
         thread_.reset();
-        initialized_ = false;
 
         return true;
     }


### PR DESCRIPTION
This is a new attempt to fix #110.
In contrast to #121 it does not use exception handling. Instead the initialized status is reset before calling shutdown. This way, event when shutdown fails, the initialized status is false.
