### PR TITLE
Recover of CAN layer works again

### DIFF
--- a/canopen_master/include/canopen_master/can_layer.h
+++ b/canopen_master/include/canopen_master/can_layer.h
@@ -82,8 +82,12 @@ public:
 	}
     }
     virtual void handleShutdown(LayerStatus &status){
+        can::StateWaiter waiter(driver_.get());
         error_listener_.reset();
         driver_->shutdown();
+        if(!waiter.wait(can::State::closed, boost::posix_time::seconds(1))){
+             status.warn("CAN shutdown timed out");
+        }
         if(thread_){
             thread_->interrupt();
             thread_->join();

--- a/canopen_master/include/canopen_master/can_layer.h
+++ b/canopen_master/include/canopen_master/can_layer.h
@@ -98,8 +98,10 @@ public:
     virtual void handleHalt(LayerStatus &status) { /* nothing to do */ }
     
     virtual void handleRecover(LayerStatus &status){
-		handleShutdown(status);
-		handleInit(status);
+        if(!driver_->getState().isReady()){
+            handleShutdown(status);
+            handleInit(status);
+        }
     }
 
 };

--- a/socketcan_interface/include/socketcan_interface/asio_base.h
+++ b/socketcan_interface/include/socketcan_interface/asio_base.h
@@ -55,6 +55,9 @@ protected:
             state_dispatcher_.dispatch(state_);
         }
     }
+    void setNotReady(){
+        setDriverState(socket_.is_open()?State::open : State::closed);
+    }
     
     void frameReceived(const boost::system::error_code& error){
         if(!error){
@@ -77,7 +80,7 @@ public:
         return state_;
     }
     virtual void run(){
-        setDriverState(socket_.is_open()?State::open : State::closed);
+        setNotReady();
         
         if(getState().driver_state == State::open){
             io_service_.reset();
@@ -92,7 +95,7 @@ public:
             io_service_.run(ec);
             setErrorCode(ec);
             
-            setDriverState(socket_.is_open()?State::open : State::closed);
+            setNotReady();
         }   
         state_dispatcher_.dispatch(getState());
     }

--- a/socketcan_interface/include/socketcan_interface/socketcan.h
+++ b/socketcan_interface/include/socketcan_interface/socketcan.h
@@ -177,7 +177,7 @@ protected:
         if(ec){
             LOG("FAILED " << ec);
             BaseClass::setErrorCode(ec);
-            BaseClass::setDriverState(State::open);
+            BaseClass::setNotReady();
             return false;
         }
         
@@ -197,7 +197,7 @@ protected:
 
                 LOG("error: " << BaseClass::input_.id);
                 BaseClass::setInternalError(BaseClass::input_.id);
-                BaseClass::setDriverState(State::open); // TODO: error reset?
+                BaseClass::setNotReady();
 
             }else{
                 BaseClass::input_.is_extended = (frame_.can_id & CAN_EFF_FLAG) ? 1 :0;


### PR DESCRIPTION
The implementation erroneously restarted the SockerCAN driver on every recover() call.
In addition some caveats prevented the driver to recover from certain situations.

The patched version survived a full load test `cangen can0 -g 0 -i -x -I 000 -L 8 -D 0000000000` and a device disconnect.
