### PR TITLE
Support for deprecated PDO remapping if COB-ID is not writable

### DIFF
--- a/canopen_master/src/pdo.cpp
+++ b/canopen_master/src/pdo.cpp
@@ -100,7 +100,7 @@ void PDOMapper::PDO::parse_and_set_mapping(const boost::shared_ptr<ObjectStorage
     storage->entry(cob_id, com_index, SUB_COM_COB_ID);
     
     bool com_changed = check_com_changed(dict, map_index);
-    if(map_changed || com_changed){
+    if((map_changed || com_changed) && cob_id.desc().writable){
         
         PDOid cur(cob_id.get());
         cur.invalid = 1;
@@ -153,7 +153,7 @@ void PDOMapper::PDO::parse_and_set_mapping(const boost::shared_ptr<ObjectStorage
     if(map_changed){
         num_entry.set(map_num);
     }
-    if(com_changed || map_changed){
+    if((com_changed || map_changed) && cob_id.desc().writable){
         storage->init(ObjectDict::Key(com_index, SUB_COM_COB_ID));
         
         cob_id.set(NodeIdOffset<uint32_t>::apply(dict(com_index, SUB_COM_COB_ID).value(), storage->node_id_));

--- a/canopen_master/src/sdo.cpp
+++ b/canopen_master/src/sdo.cpp
@@ -417,7 +417,7 @@ void SDOClient::transmitAndWait(const canopen::ObjectDict::Entry &entry, const S
         if(!reader_.read(&msg,boost::chrono::seconds(1)))
         {
             abort(0x05040000); // SDO protocol timed out.
-            LOG("Did not receivce a response message");
+            LOG("Did not receive a response message");
             break;
         }
         if(!processFrame(msg)){


### PR DESCRIPTION
Support for old CANopen nodes that do not support deactivating PDOs via COB-ID settings.
