### PR TITLE
Added option to turn off mode monitor

### DIFF
--- a/canopen_402/include/canopen_402/motor.h
+++ b/canopen_402/include/canopen_402/motor.h
@@ -293,7 +293,9 @@ class Motor402 : public MotorBase
 public:
 
     Motor402(const std::string &name, boost::shared_ptr<ObjectStorage> storage, const canopen::Settings &settings)
-    : MotorBase(name), status_word_(0),control_word_(0), switching_state_(State402::InternalState(settings.get_optional<unsigned int>("switching_state", static_cast<unsigned int>(State402::Operation_Enable))))
+    : MotorBase(name), status_word_(0),control_word_(0),
+      switching_state_(State402::InternalState(settings.get_optional<unsigned int>("switching_state", static_cast<unsigned int>(State402::Operation_Enable)))),
+      monitor_mode_(settings.get_optional<bool>("monitor_mode", true))
     {
         storage->entry(status_word_entry_, 0x6041);
         storage->entry(control_word_entry_, 0x6040);
@@ -384,6 +386,7 @@ private:
     boost::condition_variable mode_cond_;
     boost::mutex mode_mutex_;
     const State402::InternalState switching_state_;
+    const bool monitor_mode_;
 
     canopen::ObjectStorage::Entry<uint16_t>  status_word_entry_;
     canopen::ObjectStorage::Entry<uint16_t >  control_word_entry_;

--- a/canopen_test_utils/config/canopen_rig1.yaml
+++ b/canopen_test_utils/config/canopen_rig1.yaml
@@ -10,8 +10,9 @@ defaults: # optional, all defaults can be overwritten per node
     "1017": "100" # heartbeat producer
   ### 402
   # motor_allocator: canopen::Motor402::Allocator # select allocator for motor layer plugin
-  # motor_layer: settings passed to motor layer (plugin-specific)
+  # motor_layer: # settings passed to motor layer (plugin-specific)
   #   switching_state: 5 # (Operation_Enable), state for mode switching
+  #   monitor_mode: true # read operation mode in every cycle
   ### ROS:
   # publish: ["60C1sub1", "6060!"] # list of objects to be published (one topic per node and entry), ! diables caching and forces read from device
   ### ros_control: conversion functions


### PR DESCRIPTION
This is helpful if mode monitoring is not wanted/needed or if object 6061 is not mappable.
