### PR TITLE
deprecated canSwitch

### DIFF
--- a/canopen_motor_node/include/canopen_motor_node/robot_layer.h
+++ b/canopen_motor_node/include/canopen_motor_node/robot_layer.h
@@ -219,12 +219,6 @@ public:
 
     virtual void handleInit(canopen::LayerStatus &status);
     void enforce(const ros::Duration &period, bool reset);
-    virtual bool canSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list) const{
-        // compile-time check for mode switching support in ros_control
-        // if the following line fails, please upgrade to ros_control/contoller_manager 0.9.2 or newer
-        (void) &hardware_interface::RobotHW::canSwitch;
-        return const_cast<RobotLayer*>(this)->prepareSwitch(start_list, stop_list); // awful hack, do not try this at home.
-    }
     virtual bool prepareSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list);
     virtual void doSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list);
 };

--- a/canopen_motor_node/src/robot_layer.cpp
+++ b/canopen_motor_node/src/robot_layer.cpp
@@ -293,6 +293,9 @@ void RobotLayer::enforce(const ros::Duration &period, bool reset){
 }
 
 bool RobotLayer::prepareSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list) {
+    // compile-time check for mode switching support in ros_control
+    (void) &hardware_interface::RobotHW::prepareSwitch; // please upgrade to ros_control/contoller_manager 0.9.4 or newer
+
     // stop handles
     for (std::list<hardware_interface::ControllerInfo>::const_iterator controller_it = stop_list.begin(); controller_it != stop_list.end(); ++controller_it){
 


### PR DESCRIPTION
includes #150 

(will fail until new ros_control version is released)
