### PR TITLE
Add socketcan_bridge and can_msgs.

### DIFF
--- a/can_msgs/CMakeLists.txt
+++ b/can_msgs/CMakeLists.txt
@@ -11,4 +11,4 @@ add_message_files(
 
 generate_messages(DEPENDENCIES std_msgs)
 
-catkin_package(CATKIN_DEPENDS std_msgs)
+catkin_package(CATKIN_DEPENDS message_runtime std_msgs)

--- a/can_msgs/CMakeLists.txt
+++ b/can_msgs/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(can_msgs)
+
+find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)
+
+add_message_files(
+  DIRECTORY msg
+  FILES
+  Frame.msg
+)
+
+generate_messages(DEPENDENCIES std_msgs)
+
+catkin_package(CATKIN_DEPENDS std_msgs)

--- a/can_msgs/msg/Frame.msg
+++ b/can_msgs/msg/Frame.msg
@@ -1,0 +1,7 @@
+Header header
+uint32 id
+bool is_rtr
+bool is_extended
+bool is_error
+uint8 dlc
+uint8[8] data

--- a/can_msgs/package.xml
+++ b/can_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">.
   <name>can_msgs</name>
-  <version>0.0.1</version>
+  <version>0.1.0</version>
   <description>CAN related message types.</description>
 
   <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
@@ -9,10 +9,9 @@
 
   <license>BSD</license>
 
-  <url type="website">http://wiki.ros.org/ros_canopen</url>
+  <url type="website">http://wiki.ros.org/can_msgs</url>
   <url type="repository">https://github.com/ros-industrial/ros_canopen</url>
   <url type="bugtracker">https://github.com/ros-industrial/ros_canopen/issues</url>
-
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/can_msgs/package.xml
+++ b/can_msgs/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package format="2">.
+  <name>can_msgs</name>
+  <version>0.0.1</version>
+  <description>CAN related message types.</description>
+
+  <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
+  <author email="ivor@iwanders.net">Ivor Wanders</author>
+
+  <license>BSD</license>
+
+  <url type="website">http://wiki.ros.org/ros_canopen</url>
+  <url type="repository">https://github.com/ros-industrial/ros_canopen</url>
+  <url type="bugtracker">https://github.com/ros-industrial/ros_canopen/issues</url>
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>message_generation</depend>
+  <depend>std_msgs</depend>
+
+</package>

--- a/can_msgs/package.xml
+++ b/can_msgs/package.xml
@@ -15,7 +15,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>message_generation</depend>
+  <build_depend>message_generation</build_depend>
+  <exec_depend>message_runtime</exec_depend>
   <depend>std_msgs</depend>
 
 </package>

--- a/socketcan_bridge/CMakeLists.txt
+++ b/socketcan_bridge/CMakeLists.txt
@@ -54,3 +54,9 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 roslint_cpp()
 #for use with catkin_make roslint_socketcan_bridge
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  catkin_add_gtest(test_conversion test/test_conversion.cpp)
+  target_link_libraries(test_conversion topic_to_socketcan socketcan_to_topic ${catkin_LIBRARIES})
+endif()

--- a/socketcan_bridge/CMakeLists.txt
+++ b/socketcan_bridge/CMakeLists.txt
@@ -1,17 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(socketcan_bridge)
 
-find_package(catkin REQUIRED COMPONENTS
-  socketcan_interface
-  roscpp
-  can_msgs
-  roslint
-)
+find_package(catkin REQUIRED COMPONENTS can_msgs roscpp socketcan_interface)
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES socketcan_to_topic topic_to_socketcan socketcan_interface roscpp can_msgs
-  CATKIN_DEPENDS 
+  CATKIN_DEPENDS can_msgs roscpp socketcan_interface
   DEPENDS Boost
 )
 
@@ -20,11 +15,11 @@ include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 add_library(socketcan_to_topic src/socketcan_to_topic.cpp)
 target_link_libraries(socketcan_to_topic ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-add_dependencies(socketcan_to_topic can_msgs_generate_messages_cpp)
+add_dependencies(socketcan_to_topic ${catkin_EXPORTED_TARGETS})
 
 add_library(topic_to_socketcan src/topic_to_socketcan.cpp)
 target_link_libraries(topic_to_socketcan ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-add_dependencies(topic_to_socketcan can_msgs_generate_messages_cpp)
+add_dependencies(topic_to_socketcan ${catkin_EXPORTED_TARGETS})
 
 add_executable(socketcan_to_topic_node src/socketcan_to_topic_node.cpp)
 target_link_libraries(socketcan_to_topic_node socketcan_to_topic ${catkin_LIBRARIES} ${Boost_LIBRARIES})
@@ -46,14 +41,15 @@ install(TARGETS
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h")
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
-roslint_cpp()
-#for use with catkin_make roslint_socketcan_bridge
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
+  find_package(roslint REQUIRED)
+
+  roslint_cpp()
+  #for use with catkin_make roslint_socketcan_bridge
 
   # unit test for the can_msgs::Frame and can::Frame types.
   catkin_add_gtest(test_conversion test/test_conversion.cpp)

--- a/socketcan_bridge/CMakeLists.txt
+++ b/socketcan_bridge/CMakeLists.txt
@@ -23,11 +23,14 @@ catkin_package(
 include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 
+
 add_library(socketcan_to_topic src/socketcan_to_topic.cpp)
 target_link_libraries(socketcan_to_topic ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+add_dependencies(socketcan_to_topic can_msgs_generate_messages_cpp)
 
 add_library(topic_to_socketcan src/topic_to_socketcan.cpp)
 target_link_libraries(topic_to_socketcan ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+add_dependencies(topic_to_socketcan can_msgs_generate_messages_cpp)
 
 add_executable(socketcan_to_topic_node src/socketcan_to_topic_node.cpp)
 target_link_libraries(socketcan_to_topic_node socketcan_to_topic ${catkin_LIBRARIES} ${Boost_LIBRARIES})
@@ -57,6 +60,22 @@ roslint_cpp()
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
+
+  # unit test for the can_msgs::Frame and can::Frame types.
   catkin_add_gtest(test_conversion test/test_conversion.cpp)
   target_link_libraries(test_conversion topic_to_socketcan socketcan_to_topic ${catkin_LIBRARIES})
+
+
+  add_rostest_gtest(test_to_socketcan
+                    test/to_socketcan.test
+                    test/to_socketcan_test.cpp)
+  target_link_libraries(test_to_socketcan topic_to_socketcan ${catkin_LIBRARIES})
+
+  add_rostest_gtest(test_to_topic
+                    test/to_topic.test
+                    test/to_topic_test.cpp)
+  target_link_libraries(test_to_topic socketcan_to_topic ${catkin_LIBRARIES})
+
+  
+
 endif()

--- a/socketcan_bridge/CMakeLists.txt
+++ b/socketcan_bridge/CMakeLists.txt
@@ -8,9 +8,6 @@ find_package(catkin REQUIRED COMPONENTS
   roslint
 )
 
-find_package(Boost REQUIRED COMPONENTS system thread)
-
-
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES socketcan_to_topic topic_to_socketcan socketcan_interface roscpp can_msgs
@@ -18,10 +15,7 @@ catkin_package(
   DEPENDS Boost
 )
 
-
-
 include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
-
 
 
 add_library(socketcan_to_topic src/socketcan_to_topic.cpp)

--- a/socketcan_bridge/CMakeLists.txt
+++ b/socketcan_bridge/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Boost REQUIRED COMPONENTS system thread)
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES socketcan_to_topic socketcan_interface roscpp can_msgs
+  LIBRARIES socketcan_to_topic topic_to_socketcan socketcan_interface roscpp can_msgs
   CATKIN_DEPENDS 
   DEPENDS Boost
 )
@@ -26,12 +26,24 @@ include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 add_library(socketcan_to_topic src/socketcan_to_topic.cpp)
 target_link_libraries(socketcan_to_topic ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+add_library(topic_to_socketcan src/topic_to_socketcan.cpp)
+target_link_libraries(topic_to_socketcan ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
 add_executable(socketcan_to_topic_node src/socketcan_to_topic_node.cpp)
 target_link_libraries(socketcan_to_topic_node socketcan_to_topic ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+add_executable(topic_to_socketcan_node src/topic_to_socketcan_node.cpp)
+target_link_libraries(topic_to_socketcan_node topic_to_socketcan ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+add_executable(socketcan_bridge_node src/socketcan_bridge_node.cpp)
+target_link_libraries(socketcan_bridge_node topic_to_socketcan socketcan_to_topic ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS
   socketcan_to_topic
   socketcan_to_topic_node
+  topic_to_socketcan
+  topic_to_socketcan_node
+  socketcan_bridge_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/socketcan_bridge/CMakeLists.txt
+++ b/socketcan_bridge/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(socketcan_bridge)
+
+find_package(catkin REQUIRED COMPONENTS
+  socketcan_interface
+  roscpp
+  can_msgs
+  roslint
+)
+
+find_package(Boost REQUIRED COMPONENTS system thread)
+
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES socketcan_to_topic socketcan_interface roscpp can_msgs
+  CATKIN_DEPENDS 
+  DEPENDS Boost
+)
+
+
+
+include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+
+
+add_library(socketcan_to_topic src/socketcan_to_topic.cpp)
+target_link_libraries(socketcan_to_topic ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+add_executable(socketcan_to_topic_node src/socketcan_to_topic_node.cpp)
+target_link_libraries(socketcan_to_topic_node socketcan_to_topic ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+install(TARGETS
+  socketcan_to_topic
+  socketcan_to_topic_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h")
+
+roslint_cpp()
+#for use with catkin_make roslint_socketcan_bridge

--- a/socketcan_bridge/CMakeLists.txt
+++ b/socketcan_bridge/CMakeLists.txt
@@ -5,30 +5,29 @@ find_package(catkin REQUIRED COMPONENTS can_msgs roscpp socketcan_interface)
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES socketcan_to_topic topic_to_socketcan socketcan_interface roscpp can_msgs
+  LIBRARIES socketcan_to_topic topic_to_socketcan
   CATKIN_DEPENDS can_msgs roscpp socketcan_interface
-  DEPENDS Boost
 )
 
-include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 
 add_library(socketcan_to_topic src/socketcan_to_topic.cpp)
-target_link_libraries(socketcan_to_topic ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(socketcan_to_topic ${catkin_LIBRARIES})
 add_dependencies(socketcan_to_topic ${catkin_EXPORTED_TARGETS})
 
 add_library(topic_to_socketcan src/topic_to_socketcan.cpp)
-target_link_libraries(topic_to_socketcan ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(topic_to_socketcan ${catkin_LIBRARIES})
 add_dependencies(topic_to_socketcan ${catkin_EXPORTED_TARGETS})
 
 add_executable(socketcan_to_topic_node src/socketcan_to_topic_node.cpp)
-target_link_libraries(socketcan_to_topic_node socketcan_to_topic ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(socketcan_to_topic_node socketcan_to_topic ${catkin_LIBRARIES})
 
 add_executable(topic_to_socketcan_node src/topic_to_socketcan_node.cpp)
-target_link_libraries(topic_to_socketcan_node topic_to_socketcan ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(topic_to_socketcan_node topic_to_socketcan ${catkin_LIBRARIES})
 
 add_executable(socketcan_bridge_node src/socketcan_bridge_node.cpp)
-target_link_libraries(socketcan_bridge_node topic_to_socketcan socketcan_to_topic ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(socketcan_bridge_node topic_to_socketcan socketcan_to_topic ${catkin_LIBRARIES})
 
 install(TARGETS
   socketcan_to_topic

--- a/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
+++ b/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016, Ivor Wanders
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SOCKETCAN_BRIDGE_SOCKETCAN_TO_TOPIC_H
+#define SOCKETCAN_BRIDGE_SOCKETCAN_TO_TOPIC_H
+
+#include <socketcan_interface/socketcan.h>
+#include <ros/ros.h>
+
+namespace socketcan_bridge
+{
+class SocketCANToTopic
+{
+  public:
+    SocketCANToTopic(ros::NodeHandle* nh, ros::NodeHandle* nh_param, boost::shared_ptr<can::DriverInterface> driver);
+    int setup();
+
+  private:
+    ros::Publisher can_topic_;
+    boost::shared_ptr<can::DriverInterface> driver_;
+
+    can::CommInterface::FrameListener::Ptr frame_listener_;
+    can::StateInterface::StateListener::Ptr state_listener_;
+
+
+    void frameCallback(const can::Frame& f);
+    void stateCallback(const can::State & s);
+};
+
+};  // namespace socketcan_bridge
+
+
+#endif  // SOCKETCAN_BRIDGE_SOCKETCAN_TO_TOPIC_H

--- a/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
+++ b/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
@@ -38,7 +38,7 @@ class SocketCANToTopic
 {
   public:
     SocketCANToTopic(ros::NodeHandle* nh, ros::NodeHandle* nh_param, boost::shared_ptr<can::DriverInterface> driver);
-    int setup();
+    void setup();
 
   private:
     ros::Publisher can_topic_;

--- a/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
+++ b/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
@@ -59,7 +59,8 @@ void convertSocketCANToMessage(const can::Frame& f, can_msgs::Frame& m)
   m.is_error = f.is_error;
   m.is_rtr = f.is_rtr;
   m.is_extended = f.is_extended;
-  for (int i = 0; i < f.dlc; ++i)
+
+  for (int i = 0; i < 8; i++)  // always copy all data, regardless of dlc.
   {
     m.data[i] = f.data[i];
   }

--- a/socketcan_bridge/include/socketcan_bridge/topic_to_socketcan.h
+++ b/socketcan_bridge/include/socketcan_bridge/topic_to_socketcan.h
@@ -25,8 +25,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SOCKETCAN_BRIDGE_SOCKETCAN_TO_TOPIC_H
-#define SOCKETCAN_BRIDGE_SOCKETCAN_TO_TOPIC_H
+#ifndef SOCKETCAN_BRIDGE_TOPIC_TO_SOCKETCAN_H
+#define SOCKETCAN_BRIDGE_TOPIC_TO_SOCKETCAN_H
 
 #include <socketcan_interface/socketcan.h>
 #include <can_msgs/Frame.h>
@@ -34,38 +34,37 @@
 
 namespace socketcan_bridge
 {
-class SocketCANToTopic
+class TopicToSocketCAN
 {
   public:
-    SocketCANToTopic(ros::NodeHandle* nh, ros::NodeHandle* nh_param, boost::shared_ptr<can::DriverInterface> driver);
+    TopicToSocketCAN(ros::NodeHandle* nh, ros::NodeHandle* nh_param, boost::shared_ptr<can::DriverInterface> driver);
     int setup();
 
   private:
-    ros::Publisher can_topic_;
+    ros::Subscriber can_topic_;
     boost::shared_ptr<can::DriverInterface> driver_;
 
-    can::CommInterface::FrameListener::Ptr frame_listener_;
     can::StateInterface::StateListener::Ptr state_listener_;
 
-
-    void frameCallback(const can::Frame& f);
+    void msgCallback(const can_msgs::Frame::ConstPtr& msg);
     void stateCallback(const can::State & s);
 };
 
-void convertSocketCANToMessage(const can::Frame& f, can_msgs::Frame& m)
+void convertMessageToSocketCAN(const can_msgs::Frame& m, can::Frame& f)
 {
-  m.id = f.id;
-  m.dlc = f.dlc;
-  m.is_error = f.is_error;
-  m.is_rtr = f.is_rtr;
-  m.is_extended = f.is_extended;
-  for (int i = 0; i < f.dlc; ++i)
+  f.id = m.id;
+  f.dlc = m.dlc;
+  f.is_error = m.is_error;
+  f.is_rtr = m.is_rtr;
+  f.is_extended = m.is_extended;
+
+  for (int i = 0; i < m.dlc; ++i)
   {
-    m.data[i] = f.data[i];
+    f.data[i] = m.data[i];
   }
 };
 
 };  // namespace socketcan_bridge
 
 
-#endif  // SOCKETCAN_BRIDGE_SOCKETCAN_TO_TOPIC_H
+#endif  // SOCKETCAN_BRIDGE_TOPIC_TO_SOCKETCAN_H

--- a/socketcan_bridge/include/socketcan_bridge/topic_to_socketcan.h
+++ b/socketcan_bridge/include/socketcan_bridge/topic_to_socketcan.h
@@ -38,7 +38,7 @@ class TopicToSocketCAN
 {
   public:
     TopicToSocketCAN(ros::NodeHandle* nh, ros::NodeHandle* nh_param, boost::shared_ptr<can::DriverInterface> driver);
-    int setup();
+    void setup();
 
   private:
     ros::Subscriber can_topic_;

--- a/socketcan_bridge/include/socketcan_bridge/topic_to_socketcan.h
+++ b/socketcan_bridge/include/socketcan_bridge/topic_to_socketcan.h
@@ -58,7 +58,7 @@ void convertMessageToSocketCAN(const can_msgs::Frame& m, can::Frame& f)
   f.is_rtr = m.is_rtr;
   f.is_extended = m.is_extended;
 
-  for (int i = 0; i < m.dlc; ++i)
+  for (int i = 0; i < 8; i++)  // always copy all data, regardless of dlc.
   {
     f.data[i] = m.data[i];
   }

--- a/socketcan_bridge/package.xml
+++ b/socketcan_bridge/package.xml
@@ -20,7 +20,6 @@
   <depend>roscpp</depend>
 
   <test_depend>roslint</test_depend>
-  <test_depend>gtest</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>
 </package>

--- a/socketcan_bridge/package.xml
+++ b/socketcan_bridge/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>socketcan_bridge</name>
+  <version>0.0.1</version>
+  <description>Provides a node to bridge the CAN frames from socketcan to a ROS topic.</description>
+
+  <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
+  <author email="ivor@iwanders.net">Ivor Wanders</author>
+
+  <license>BSD</license>
+
+  <!-- <url type="website">http://wiki.ros.org/canopen_master</url> -->
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roslint</build_depend>
+
+  <depend>can_msgs</depend>
+  <depend>socketcan_interface</depend>
+  <depend>boost</depend>
+  <depend>roscpp</depend>
+
+  <test_depend>roslint</test_depend>
+</package>

--- a/socketcan_bridge/package.xml
+++ b/socketcan_bridge/package.xml
@@ -17,10 +17,10 @@
 
   <depend>can_msgs</depend>
   <depend>socketcan_interface</depend>
-  <depend>boost</depend>
   <depend>roscpp</depend>
 
   <test_depend>roslint</test_depend>
   <test_depend>gtest</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
 </package>

--- a/socketcan_bridge/package.xml
+++ b/socketcan_bridge/package.xml
@@ -21,4 +21,5 @@
 
   <test_depend>roslint</test_depend>
   <test_depend>gtest</test_depend>
+  <test_depend>rostest</test_depend>
 </package>

--- a/socketcan_bridge/package.xml
+++ b/socketcan_bridge/package.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>socketcan_bridge</name>
-  <version>0.0.1</version>
-  <description>Provides a node to bridge the CAN frames from socketcan to a ROS topic.</description>
+  <version>0.1.0</version>
+  <description>Provides nodes to convert messages from SocketCAN to a ROS Topic and vice versa.</description>
 
   <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
   <author email="ivor@iwanders.net">Ivor Wanders</author>
 
   <license>BSD</license>
 
-  <!-- <url type="website">http://wiki.ros.org/canopen_master</url> -->
+  <url type="website">http://wiki.ros.org/socketcan_bridge</url>
+  <url type="repository">https://github.com/ros-industrial/ros_canopen</url>
+  <url type="bugtracker">https://github.com/ros-industrial/ros_canopen/issues</url>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslint</build_depend>

--- a/socketcan_bridge/package.xml
+++ b/socketcan_bridge/package.xml
@@ -14,7 +14,6 @@
   <url type="bugtracker">https://github.com/ros-industrial/ros_canopen/issues</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roslint</build_depend>
 
   <depend>can_msgs</depend>
   <depend>socketcan_interface</depend>

--- a/socketcan_bridge/package.xml
+++ b/socketcan_bridge/package.xml
@@ -20,4 +20,5 @@
   <depend>roscpp</depend>
 
   <test_depend>roslint</test_depend>
+  <test_depend>gtest</test_depend>
 </package>

--- a/socketcan_bridge/src/socketcan_bridge_node.cpp
+++ b/socketcan_bridge/src/socketcan_bridge_node.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {
     ROS_FATAL("Failed to initialize can_device at %s", can_device.c_str());
-    return -1;
+    return 1;
   }
     else
   {

--- a/socketcan_bridge/src/socketcan_bridge_node.cpp
+++ b/socketcan_bridge/src/socketcan_bridge_node.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
 
   if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {
-    ROS_ERROR("Failed to initialize can_device at %s", can_device.c_str());
+    ROS_FATAL("Failed to initialize can_device at %s", can_device.c_str());
     return -1;
   }
     else

--- a/socketcan_bridge/src/socketcan_bridge_node.cpp
+++ b/socketcan_bridge/src/socketcan_bridge_node.cpp
@@ -25,47 +25,45 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SOCKETCAN_BRIDGE_SOCKETCAN_TO_TOPIC_H
-#define SOCKETCAN_BRIDGE_SOCKETCAN_TO_TOPIC_H
-
-#include <socketcan_interface/socketcan.h>
-#include <can_msgs/Frame.h>
 #include <ros/ros.h>
+#include <socketcan_bridge/topic_to_socketcan.h>
+#include <socketcan_bridge/socketcan_to_topic.h>
+#include <socketcan_interface/threading.h>
+#include <string>
 
-namespace socketcan_bridge
+
+int main(int argc, char *argv[])
 {
-class SocketCANToTopic
-{
-  public:
-    SocketCANToTopic(ros::NodeHandle* nh, ros::NodeHandle* nh_param, boost::shared_ptr<can::DriverInterface> driver);
-    int setup();
+  ros::init(argc, argv, "socketcan_bridge_node");
 
-  private:
-    ros::Publisher can_topic_;
-    boost::shared_ptr<can::DriverInterface> driver_;
+  ros::NodeHandle nh(""), nh_param("~");
 
-    can::CommInterface::FrameListener::Ptr frame_listener_;
-    can::StateInterface::StateListener::Ptr state_listener_;
+  std::string can_device;
+  nh_param.param<std::string>("can_device", can_device, "can0");
 
+  boost::shared_ptr<can::ThreadedSocketCANInterface> driver = boost::make_shared<can::ThreadedSocketCANInterface> ();
 
-    void frameCallback(const can::Frame& f);
-    void stateCallback(const can::State & s);
-};
-
-void convertSocketCANToMessage(const can::Frame& f, can_msgs::Frame& m)
-{
-  m.id = f.id;
-  m.dlc = f.dlc;
-  m.is_error = f.is_error;
-  m.is_rtr = f.is_rtr;
-  m.is_extended = f.is_extended;
-  for (int i = 0; i < f.dlc; ++i)
+  if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {
-    m.data[i] = f.data[i];
+    ROS_ERROR("Failed to initialize can_device at %s", can_device.c_str());
+    return -1;
   }
-};
+    else
+  {
+    ROS_INFO("Successfully connected to %s.", can_device.c_str());
+  }
 
-};  // namespace socketcan_bridge
+  // initialize the bridge both ways.
+  socketcan_bridge::TopicToSocketCAN to_socketcan_bridge(&nh, &nh_param, driver);
+  to_socketcan_bridge.setup();
 
+  socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver);
+  to_topic_bridge.setup();
 
-#endif  // SOCKETCAN_BRIDGE_SOCKETCAN_TO_TOPIC_H
+  ros::spin();
+
+  driver->shutdown();
+  driver.reset();
+
+  ros::waitForShutdown();
+}

--- a/socketcan_bridge/src/socketcan_to_topic.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2016, Ivor Wanders
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <socketcan_bridge/socketcan_to_topic.h>
+#include <socketcan_interface/string.h>
+#include <can_msgs/Frame.h>
+#include <string>
+
+namespace socketcan_bridge
+{
+  SocketCANToTopic::SocketCANToTopic(ros::NodeHandle* nh, ros::NodeHandle* nh_param,
+      boost::shared_ptr<can::DriverInterface> driver)
+    {
+      can_topic_ = nh->advertise<can_msgs::Frame>("received_messages", 10);
+      driver_ = driver;
+    };
+
+  int SocketCANToTopic::setup()
+    {
+      // register handler for frames and state changes.
+      frame_listener_ = driver_->createMsgListener(
+              can::CommInterface::FrameDelegate(this, &SocketCANToTopic::frameCallback));
+
+      state_listener_ = driver_->createStateListener(
+              can::StateInterface::StateDelegate(this, &SocketCANToTopic::stateCallback));
+    };
+
+  void SocketCANToTopic::frameCallback(const can::Frame& f)
+    {
+      ROS_DEBUG("Message came in: %s", can::tostring(f, true).c_str());
+
+      if (f.is_error)
+        {
+          ROS_WARN("Message is error: %s", can::tostring(f, true).c_str());
+        }
+
+      can_msgs::Frame msg;
+      msg.id = f.id;
+      msg.dlc = f.dlc;
+      msg.is_error = f.is_error;
+      msg.is_rtr = f.is_rtr;
+      msg.is_extended = f.is_extended;
+
+      msg.header.frame_id = "0";  // "0" for no frame.
+      msg.header.stamp = ros::Time::now();
+
+      for (int i = 0; i < f.dlc; ++i)
+        {
+          msg.data[i] = f.data[i];
+        }
+      can_topic_.publish(msg);
+    };
+
+
+  void SocketCANToTopic::stateCallback(const can::State & s)
+    {
+      std::string err;
+      driver_->translateError(s.internal_error, err);
+      ROS_ERROR("Error: %s, asio: %s", err.c_str(), s.error_code.message().c_str());
+    };
+};  // namespace socketcan_bridge

--- a/socketcan_bridge/src/socketcan_to_topic.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic.cpp
@@ -39,7 +39,7 @@ namespace socketcan_bridge
       driver_ = driver;
     };
 
-  int SocketCANToTopic::setup()
+  void SocketCANToTopic::setup()
     {
       // register handler for frames and state changes.
       frame_listener_ = driver_->createMsgListener(

--- a/socketcan_bridge/src/socketcan_to_topic.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic.cpp
@@ -73,7 +73,7 @@ namespace socketcan_bridge
       // converts the can::Frame (socketcan.h) to can_msgs::Frame (ROS msg)
       convertSocketCANToMessage(frame, msg);
 
-      msg.header.frame_id = "0";  // "0" for no frame.
+      msg.header.frame_id = "";  // empty frame is the de-facto standard for no frame.
       msg.header.stamp = ros::Time::now();
 
       can_topic_.publish(msg);

--- a/socketcan_bridge/src/socketcan_to_topic_node.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic_node.cpp
@@ -28,6 +28,7 @@
 #include <ros/ros.h>
 #include <socketcan_bridge/socketcan_to_topic.h>
 #include <socketcan_interface/threading.h>
+#include <socketcan_interface/string.h>
 #include <string>
 
 
@@ -41,9 +42,7 @@ int main(int argc, char *argv[])
   std::string can_device;
   nh_param.param<std::string>("can_device", can_device, "can0");
 
-
   boost::shared_ptr<can::ThreadedSocketCANInterface> driver = boost::make_shared<can::ThreadedSocketCANInterface> ();
-
 
   if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {

--- a/socketcan_bridge/src/socketcan_to_topic_node.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic_node.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2016, Ivor Wanders
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ros/ros.h>
+#include <socketcan_bridge/socketcan_to_topic.h>
+#include <socketcan_interface/threading.h>
+#include <string>
+
+
+
+int main(int argc, char *argv[])
+{
+  ros::init(argc, argv, "socketcan_to_topic_node");
+
+  ros::NodeHandle nh(""), nh_param("~");
+
+  std::string can_device;
+  nh_param.param<std::string>("can_device", can_device, "can0");
+
+
+  boost::shared_ptr<can::ThreadedSocketCANInterface> driver = boost::make_shared<can::ThreadedSocketCANInterface> ();
+
+
+  if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
+  {
+    ROS_ERROR("Failed to initialize can_device at %s", can_device.c_str());
+    return -1;
+  }
+    else
+  {
+    ROS_INFO("Successfully connected to %s.", can_device.c_str());
+  }
+
+  socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver);
+  to_topic_bridge.setup();
+
+  ros::spin();
+
+  driver->shutdown();
+  driver.reset();
+
+  ros::waitForShutdown();
+}

--- a/socketcan_bridge/src/socketcan_to_topic_node.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic_node.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
 
   if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {
-    ROS_ERROR("Failed to initialize can_device at %s", can_device.c_str());
+    ROS_FATAL("Failed to initialize can_device at %s", can_device.c_str());
     return -1;
   }
     else

--- a/socketcan_bridge/src/socketcan_to_topic_node.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic_node.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
   if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {
     ROS_FATAL("Failed to initialize can_device at %s", can_device.c_str());
-    return -1;
+    return 1;
   }
     else
   {

--- a/socketcan_bridge/src/topic_to_socketcan.cpp
+++ b/socketcan_bridge/src/topic_to_socketcan.cpp
@@ -39,7 +39,7 @@ namespace socketcan_bridge
       driver_ = driver;
     };
 
-  int TopicToSocketCAN::setup()
+  void TopicToSocketCAN::setup()
     {
       state_listener_ = driver_->createStateListener(
               can::StateInterface::StateDelegate(this, &TopicToSocketCAN::stateCallback));

--- a/socketcan_bridge/src/topic_to_socketcan.cpp
+++ b/socketcan_bridge/src/topic_to_socketcan.cpp
@@ -50,6 +50,7 @@ namespace socketcan_bridge
       // ROS_DEBUG("Message came from sent_messages topic");
 
       // translate it to the socketcan frame type.
+
       can_msgs::Frame m = *msg.get();  // ROS message
       can::Frame f;  // socketcan type
 
@@ -58,14 +59,17 @@ namespace socketcan_bridge
 
       if (!f.isValid())  // check if the id and flags are appropriate.
       {
-        ROS_WARN("Refusing to send invalid frame: %s.", can::tostring(f, true).c_str());
+        // ROS_WARN("Refusing to send invalid frame: %s.", can::tostring(f, true).c_str());
+        // can::tostring cannot be used for dlc > 8 frames. It causes an crash
+        // due to usage of boost::array for the data array. The should always work.
+        ROS_ERROR("Invalid frame from topic: id: %#04x, length: %d, is_extended: %d", m.id, m.dlc, m.is_extended);
         return;
       }
 
       bool res = driver_->send(f);
       if (!res)
       {
-        ROS_WARN("Failed to send message: %s.", can::tostring(f, true).c_str());
+        ROS_ERROR("Failed to send message: %s.", can::tostring(f, true).c_str());
       }
     };
 

--- a/socketcan_bridge/src/topic_to_socketcan_node.cpp
+++ b/socketcan_bridge/src/topic_to_socketcan_node.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
 
   if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {
-    ROS_ERROR("Failed to initialize can_device at %s", can_device.c_str());
+    ROS_FATAL("Failed to initialize can_device at %s", can_device.c_str());
     return -1;
   }
     else

--- a/socketcan_bridge/src/topic_to_socketcan_node.cpp
+++ b/socketcan_bridge/src/topic_to_socketcan_node.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
   if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {
     ROS_FATAL("Failed to initialize can_device at %s", can_device.c_str());
-    return -1;
+    return 1;
   }
     else
   {

--- a/socketcan_bridge/test/initialize_vcan.sh
+++ b/socketcan_bridge/test/initialize_vcan.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+lsmod | grep -q "vcan"
+VCAN_NOT_LOADED=$?
+
+if [ $VCAN_NOT_LOADED -eq 1 ]; then
+    echo "vcan kernel module is not available..."
+    echo "loading it;"
+    sudo modprobe -a vcan
+    exit;
+fi
+
+ifconfig vcan0 > /dev/null
+VCAN_NOT_EXIST=$?
+
+if [ $VCAN_NOT_EXIST -eq 1 ]; then
+  echo "vcan0 does not exist, creating it."
+  sudo ip link add dev vcan0 type vcan
+  sudo ip link set vcan0 up
+else
+  echo "vcan0 already exists."
+fi
+

--- a/socketcan_bridge/test/initialize_vcan.sh
+++ b/socketcan_bridge/test/initialize_vcan.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# sets up two virtual can interfaces, vcan0 and vcan1
+
 lsmod | grep -q "vcan"
 VCAN_NOT_LOADED=$?
 

--- a/socketcan_bridge/test/initialize_vcan.sh
+++ b/socketcan_bridge/test/initialize_vcan.sh
@@ -7,7 +7,6 @@ if [ $VCAN_NOT_LOADED -eq 1 ]; then
     echo "vcan kernel module is not available..."
     echo "loading it;"
     sudo modprobe -a vcan
-    exit;
 fi
 
 ifconfig vcan0 > /dev/null
@@ -17,6 +16,17 @@ if [ $VCAN_NOT_EXIST -eq 1 ]; then
   echo "vcan0 does not exist, creating it."
   sudo ip link add dev vcan0 type vcan
   sudo ip link set vcan0 up
+else
+  echo "vcan0 already exists."
+fi
+
+
+ifconfig vcan1 > /dev/null
+VCAN_NOT_EXIST=$?
+if [ $VCAN_NOT_EXIST -eq 1 ]; then
+  echo "vcan0 does not exist, creating it."
+  sudo ip link add dev vcan1 type vcan
+  sudo ip link set vcan1 up
 else
   echo "vcan0 already exists."
 fi

--- a/socketcan_bridge/test/test_conversion.cpp
+++ b/socketcan_bridge/test/test_conversion.cpp
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2016, Ivor Wanders
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 #include <socketcan_bridge/topic_to_socketcan.h>
 #include <socketcan_bridge/socketcan_to_topic.h>
 
@@ -13,7 +39,7 @@ TEST(ConversionTest, socketCANToTopicStandard)
 {
   can::Frame f;
   can_msgs::Frame m;
-  f.id = 127; 
+  f.id = 127;
   f.dlc = 8;
   f.is_error = false;
   f.is_rtr = false;
@@ -22,15 +48,15 @@ TEST(ConversionTest, socketCANToTopicStandard)
   {
     f.data[i] = i;
   }
-  socketcan_bridge::convertSocketCANToMessage(f, m); 
+  socketcan_bridge::convertSocketCANToMessage(f, m);
   EXPECT_EQ(127, m.id);
   EXPECT_EQ(8, m.dlc);
   EXPECT_EQ(false, m.is_error);
   EXPECT_EQ(false, m.is_rtr);
   EXPECT_EQ(false, m.is_extended);
 
-
-  for (uint8_t i=0; i < 8; i++){
+  for (uint8_t i=0; i < 8; i++)
+  {
     EXPECT_EQ(i, m.data[i]);
   }
 }
@@ -42,17 +68,17 @@ TEST(ConversionTest, socketCANToTopicFlags)
   can_msgs::Frame m;
 
   f.is_error = true;
-  socketcan_bridge::convertSocketCANToMessage(f, m); 
+  socketcan_bridge::convertSocketCANToMessage(f, m);
   EXPECT_EQ(true, m.is_error);
   f.is_error = false;
 
   f.is_rtr = true;
-  socketcan_bridge::convertSocketCANToMessage(f, m); 
+  socketcan_bridge::convertSocketCANToMessage(f, m);
   EXPECT_EQ(true, m.is_rtr);
   f.is_rtr = false;
-  
+
   f.is_extended = true;
-  socketcan_bridge::convertSocketCANToMessage(f, m); 
+  socketcan_bridge::convertSocketCANToMessage(f, m);
   EXPECT_EQ(true, m.is_extended);
   f.is_extended = false;
 }
@@ -62,7 +88,7 @@ TEST(ConversionTest, topicToSocketCANStandard)
 {
   can::Frame f;
   can_msgs::Frame m;
-  m.id = 127; 
+  m.id = 127;
   m.dlc = 8;
   m.is_error = false;
   m.is_rtr = false;
@@ -71,7 +97,7 @@ TEST(ConversionTest, topicToSocketCANStandard)
   {
     m.data[i] = i;
   }
-  socketcan_bridge::convertMessageToSocketCAN(m, f); 
+  socketcan_bridge::convertMessageToSocketCAN(m, f);
   EXPECT_EQ(127, f.id);
   EXPECT_EQ(8, f.dlc);
   EXPECT_EQ(false, f.is_error);
@@ -79,7 +105,8 @@ TEST(ConversionTest, topicToSocketCANStandard)
   EXPECT_EQ(false, f.is_extended);
 
 
-  for (uint8_t i=0; i < 8; i++){
+  for (uint8_t i=0; i < 8; i++)
+  {
     EXPECT_EQ(i, f.data[i]);
   }
 }
@@ -90,23 +117,24 @@ TEST(ConversionTest, topicToSocketCANFlags)
   can_msgs::Frame m;
 
   m.is_error = true;
-  socketcan_bridge::convertMessageToSocketCAN(m, f); 
+  socketcan_bridge::convertMessageToSocketCAN(m, f);
   EXPECT_EQ(true, f.is_error);
   m.is_error = false;
 
   m.is_rtr = true;
-  socketcan_bridge::convertMessageToSocketCAN(m, f); 
+  socketcan_bridge::convertMessageToSocketCAN(m, f);
   EXPECT_EQ(true, f.is_rtr);
   m.is_rtr = false;
-  
+
   m.is_extended = true;
-  socketcan_bridge::convertMessageToSocketCAN(m, f); 
+  socketcan_bridge::convertMessageToSocketCAN(m, f);
   EXPECT_EQ(true, f.is_extended);
   m.is_extended = false;
 }
 
 // Run all the tests that were declared with TEST()
-int main(int argc, char **argv){
+int main(int argc, char **argv)
+{
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/socketcan_bridge/test/test_conversion.cpp
+++ b/socketcan_bridge/test/test_conversion.cpp
@@ -1,0 +1,112 @@
+#include <socketcan_bridge/topic_to_socketcan.h>
+#include <socketcan_bridge/socketcan_to_topic.h>
+
+#include <can_msgs/Frame.h>
+#include <socketcan_interface/socketcan.h>
+
+// Bring in gtest
+#include <gtest/gtest.h>
+
+// test whether the content of a conversion from a SocketCAN frame
+// to a ROS message correctly maintains the data.
+TEST(ConversionTest, socketCANToTopicStandard)
+{
+  can::Frame f;
+  can_msgs::Frame m;
+  f.id = 127; 
+  f.dlc = 8;
+  f.is_error = false;
+  f.is_rtr = false;
+  f.is_extended = false;
+  for (uint8_t i = 0; i < f.dlc; ++i)
+  {
+    f.data[i] = i;
+  }
+  socketcan_bridge::convertSocketCANToMessage(f, m); 
+  EXPECT_EQ(127, m.id);
+  EXPECT_EQ(8, m.dlc);
+  EXPECT_EQ(false, m.is_error);
+  EXPECT_EQ(false, m.is_rtr);
+  EXPECT_EQ(false, m.is_extended);
+
+
+  for (uint8_t i=0; i < 8; i++){
+    EXPECT_EQ(i, m.data[i]);
+  }
+}
+
+// test all three flags seperately.
+TEST(ConversionTest, socketCANToTopicFlags)
+{
+  can::Frame f;
+  can_msgs::Frame m;
+
+  f.is_error = true;
+  socketcan_bridge::convertSocketCANToMessage(f, m); 
+  EXPECT_EQ(true, m.is_error);
+  f.is_error = false;
+
+  f.is_rtr = true;
+  socketcan_bridge::convertSocketCANToMessage(f, m); 
+  EXPECT_EQ(true, m.is_rtr);
+  f.is_rtr = false;
+  
+  f.is_extended = true;
+  socketcan_bridge::convertSocketCANToMessage(f, m); 
+  EXPECT_EQ(true, m.is_extended);
+  f.is_extended = false;
+}
+
+// idem, but the other way around.
+TEST(ConversionTest, topicToSocketCANStandard)
+{
+  can::Frame f;
+  can_msgs::Frame m;
+  m.id = 127; 
+  m.dlc = 8;
+  m.is_error = false;
+  m.is_rtr = false;
+  m.is_extended = false;
+  for (uint8_t i = 0; i < m.dlc; ++i)
+  {
+    m.data[i] = i;
+  }
+  socketcan_bridge::convertMessageToSocketCAN(m, f); 
+  EXPECT_EQ(127, f.id);
+  EXPECT_EQ(8, f.dlc);
+  EXPECT_EQ(false, f.is_error);
+  EXPECT_EQ(false, f.is_rtr);
+  EXPECT_EQ(false, f.is_extended);
+
+
+  for (uint8_t i=0; i < 8; i++){
+    EXPECT_EQ(i, f.data[i]);
+  }
+}
+
+TEST(ConversionTest, topicToSocketCANFlags)
+{
+  can::Frame f;
+  can_msgs::Frame m;
+
+  m.is_error = true;
+  socketcan_bridge::convertMessageToSocketCAN(m, f); 
+  EXPECT_EQ(true, f.is_error);
+  m.is_error = false;
+
+  m.is_rtr = true;
+  socketcan_bridge::convertMessageToSocketCAN(m, f); 
+  EXPECT_EQ(true, f.is_rtr);
+  m.is_rtr = false;
+  
+  m.is_extended = true;
+  socketcan_bridge::convertMessageToSocketCAN(m, f); 
+  EXPECT_EQ(true, f.is_extended);
+  m.is_extended = false;
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/socketcan_bridge/test/to_socketcan.test
+++ b/socketcan_bridge/test/to_socketcan.test
@@ -1,0 +1,3 @@
+<launch>
+    <test test-name="test_to_socketcan" pkg="socketcan_bridge" type="test_to_socketcan" clear_params="true" time-limit="10.0" />
+</launch>

--- a/socketcan_bridge/test/to_socketcan_test.cpp
+++ b/socketcan_bridge/test/to_socketcan_test.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2016, Ivor Wanders
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <socketcan_bridge/topic_to_socketcan.h>
+
+#include <can_msgs/Frame.h>
+#include <socketcan_interface/socketcan.h>
+#include <socketcan_interface/dummy.h>
+
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+#include <list>
+
+class frameCollector
+{
+  public:
+    std::list<can::Frame> frames;
+
+    frameCollector() {}
+
+    void frameCallback(const can::Frame& f)
+    {
+      frames.push_back(f);
+    }
+};
+
+TEST(TopicToSocketCANTest, checkCorrectData)
+{
+  ros::NodeHandle nh(""), nh_param("~");
+
+  // create the dummy interface
+  boost::shared_ptr<can::DummyInterface> driver_ = boost::make_shared<can::DummyInterface>(true);
+
+  // start the to topic bridge.
+  socketcan_bridge::TopicToSocketCAN to_socketcan_bridge(&nh, &nh_param, driver_);
+  to_socketcan_bridge.setup();
+
+  // register for messages on received_messages.
+  ros::Publisher publisher_ = nh.advertise<can_msgs::Frame>("sent_messages", 10);
+
+  // create a frame collector.
+  frameCollector frame_collector_;
+
+  //  driver->createMsgListener(&frameCallback);
+  can::CommInterface::FrameListener::Ptr frame_listener_ = driver_->createMsgListener(
+            can::CommInterface::FrameDelegate(&frame_collector_, &frameCollector::frameCallback));
+
+  // create a message
+  can_msgs::Frame msg;
+  msg.is_extended = true;
+  msg.is_rtr = false;
+  msg.is_error = false;
+  msg.id = 0x1337;
+  msg.dlc = 8;
+  for (uint8_t i=0; i < msg.dlc; i++)
+  {
+    msg.data[i] = i;
+  }
+
+  msg.header.frame_id = "0";  // "0" for no frame.
+  msg.header.stamp = ros::Time::now();
+
+  // send the can_frame::Frame message to the sent_messages topic.
+  publisher_.publish(msg);
+
+  // give some time for the interface some time to process the message
+  ros::WallDuration(1.0).sleep();
+  ros::spinOnce();
+
+  can::Frame received;
+  received = frame_collector_.frames.back();
+  EXPECT_EQ(received.id, msg.id);
+  EXPECT_EQ(received.dlc, msg.dlc);
+  EXPECT_EQ(received.is_extended, msg.is_extended);
+  EXPECT_EQ(received.is_rtr, msg.is_rtr);
+  EXPECT_EQ(received.is_error, msg.is_error);
+  EXPECT_EQ(received.data, msg.data);
+}
+
+TEST(TopicToSocketCANTest, checkInvalidFrameHandling)
+{
+  // - tries to send a non-extended frame with an id larger than 11 bits.
+  //   that should not be sent.
+  // - verifies that sending one larger than 11 bits actually works.
+  // - tries sending a message with a dlc > 8 bytes, this should not be sent.
+  //   sending with 8 bytes is verified by the checkCorrectData testcase.
+
+  ros::NodeHandle nh(""), nh_param("~");
+
+  // create the dummy interface
+  boost::shared_ptr<can::DummyInterface> driver_ = boost::make_shared<can::DummyInterface>(true);
+
+  // start the to topic bridge.
+  socketcan_bridge::TopicToSocketCAN to_socketcan_bridge(&nh, &nh_param, driver_);
+  to_socketcan_bridge.setup();
+
+  // register for messages on received_messages.
+  ros::Publisher publisher_ = nh.advertise<can_msgs::Frame>("sent_messages", 10);
+
+  // create a frame collector.
+  frameCollector frame_collector_;
+
+  //  add callback to the dummy interface.
+  can::CommInterface::FrameListener::Ptr frame_listener_ = driver_->createMsgListener(
+          can::CommInterface::FrameDelegate(&frame_collector_, &frameCollector::frameCallback));
+
+  // create a message
+  can_msgs::Frame msg;
+  msg.is_extended = false;
+  msg.id = (1<<11)+1;  // this is an illegal CAN packet... should not be sent.
+  msg.header.frame_id = "0";  // "0" for no frame.
+  msg.header.stamp = ros::Time::now();
+
+  // send the can_frame::Frame message to the sent_messages topic.
+  publisher_.publish(msg);
+
+  // give some time for the interface some time to process the message
+  ros::WallDuration(1.0).sleep();
+  ros::spinOnce();
+  EXPECT_EQ(frame_collector_.frames.size(), 0);
+
+  msg.is_extended = true;
+  msg.id = (1<<11)+1;  // now it should be alright.
+  // send the can_frame::Frame message to the sent_messages topic.
+  publisher_.publish(msg);
+  ros::WallDuration(1.0).sleep();
+  ros::spinOnce();
+  EXPECT_EQ(frame_collector_.frames.size(), 1);
+
+  // wipe the frame queue.
+  frame_collector_.frames.clear();
+
+
+  // finally, check if frames with a dlc > 8 are discarded.
+  msg.dlc = 10;
+  publisher_.publish(msg);
+  ros::WallDuration(1.0).sleep();
+  ros::spinOnce();
+  EXPECT_EQ(frame_collector_.frames.size(), 0);
+}
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "test_to_topic");
+  ros::WallDuration(1.0).sleep();
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/socketcan_bridge/test/to_socketcan_test.cpp
+++ b/socketcan_bridge/test/to_socketcan_test.cpp
@@ -58,6 +58,9 @@ TEST(TopicToSocketCANTest, checkCorrectData)
   socketcan_bridge::TopicToSocketCAN to_socketcan_bridge(&nh, &nh_param, driver_);
   to_socketcan_bridge.setup();
 
+  // init the driver to test stateListener (not checked automatically).
+  driver_->init("string_not_used", true);
+
   // register for messages on received_messages.
   ros::Publisher publisher_ = nh.advertise<can_msgs::Frame>("sent_messages", 10);
 

--- a/socketcan_bridge/test/to_topic.test
+++ b/socketcan_bridge/test/to_topic.test
@@ -1,0 +1,3 @@
+<launch>
+    <test test-name="test_to_topic" pkg="socketcan_bridge" type="test_to_topic" clear_params="true" time-limit="10.0" />
+</launch>

--- a/socketcan_bridge/test/to_topic_test.cpp
+++ b/socketcan_bridge/test/to_topic_test.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2016, Ivor Wanders
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <socketcan_bridge/socketcan_to_topic.h>
+
+#include <can_msgs/Frame.h>
+#include <socketcan_interface/socketcan.h>
+#include <socketcan_interface/dummy.h>
+
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+#include <list>
+
+class msgCollector
+{
+  public:
+    std::list<can_msgs::Frame> messages;
+
+    msgCollector() {}
+
+    void msgCallback(const can_msgs::Frame& f)
+    {
+      messages.push_back(f);
+    }
+};
+
+
+TEST(SocketCANToTopicTest, checkCorrectData)
+{
+  ros::NodeHandle nh(""), nh_param("~");
+
+  // create the dummy interface
+  boost::shared_ptr<can::DummyInterface> driver_ = boost::make_shared<can::DummyInterface>(true);
+
+  // start the to topic bridge.
+  socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver_);
+  to_topic_bridge.setup();  // initiate the message callbacks
+
+  // create a frame collector.
+  msgCollector message_collector_;
+
+  // register for messages on received_messages.
+  ros::Subscriber subscriber_ = nh.subscribe("received_messages", 1, &msgCollector::msgCallback, &message_collector_);
+
+  // create a can frame
+  can::Frame f;
+  f.is_extended = true;
+  f.is_rtr = false;
+  f.is_error = false;
+  f.id = 0x1337;
+  f.dlc = 8;
+  for (uint8_t i=0; i < f.dlc; i++)
+  {
+    f.data[i] = i;
+  }
+
+  // send the can frame to the driver
+  driver_->send(f);
+
+  // give some time for the interface some time to process the message
+  ros::WallDuration(1.0).sleep();
+  ros::spinOnce();
+
+  // compare the received can_msgs::Frame message to the sent can::Frame.
+  can_msgs::Frame received;
+  received = message_collector_.messages.back();
+  EXPECT_EQ(received.id, f.id);
+  EXPECT_EQ(received.dlc, f.dlc);
+  EXPECT_EQ(received.is_extended, f.is_extended);
+  EXPECT_EQ(received.is_rtr, f.is_rtr);
+  EXPECT_EQ(received.is_error, f.is_error);
+  EXPECT_EQ(received.data, f.data);
+}
+
+TEST(SocketCANToTopicTest, checkInvalidFrameHandling)
+{
+  // - tries to send a non-extended frame with an id larger than 11 bits.
+  //   that should not be sent.
+  // - verifies that sending one larger than 11 bits actually works.
+
+  // sending a message with a dlc > 8 is not possible as the DummyInterface
+  // causes a crash then.
+
+  ros::NodeHandle nh(""), nh_param("~");
+
+  // create the dummy interface
+  boost::shared_ptr<can::DummyInterface> driver_ = boost::make_shared<can::DummyInterface>(true);
+
+  // start the to topic bridge.
+  socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver_);
+  to_topic_bridge.setup();  // initiate the message callbacks
+
+  // create a frame collector.
+  msgCollector message_collector_;
+
+  // register for messages on received_messages.
+  ros::Subscriber subscriber_ = nh.subscribe("received_messages", 1, &msgCollector::msgCallback, &message_collector_);
+
+  // create a message
+  can::Frame f;
+  f.is_extended = false;
+  f.id = (1<<11)+1;  // this is an illegal CAN packet... should not be sent.
+
+  // send the can::Frame over the driver.
+  // driver_->send(f);
+
+  // give some time for the interface some time to process the message
+  ros::WallDuration(1.0).sleep();
+  ros::spinOnce();
+  EXPECT_EQ(message_collector_.messages.size(), 0);
+
+  f.is_extended = true;
+  f.id = (1<<11)+1;  // now it should be alright.
+
+  driver_->send(f);
+  ros::WallDuration(1.0).sleep();
+  ros::spinOnce();
+  EXPECT_EQ(message_collector_.messages.size(), 1);
+}
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "test_to_topic");
+  ros::WallDuration(1.0).sleep();
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/socketcan_bridge/test/to_topic_test.cpp
+++ b/socketcan_bridge/test/to_topic_test.cpp
@@ -59,6 +59,9 @@ TEST(SocketCANToTopicTest, checkCorrectData)
   socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver_);
   to_topic_bridge.setup();  // initiate the message callbacks
 
+  // init the driver to test stateListener (not checked automatically).
+  driver_->init("string_not_used", true);
+
   // create a frame collector.
   msgCollector message_collector_;
 

--- a/socketcan_bridge/test/vcan0_to_vcan1.launch
+++ b/socketcan_bridge/test/vcan0_to_vcan1.launch
@@ -1,5 +1,17 @@
 <launch>
-    
+    <!-- 
+        This launchfile expects two virtual can interfaces, vcan0 and vcan1. One node sends messages received
+        on vcan0 to the ros topic received_messages, another node passes the messages received here to vcan1.
+
+        With the can-utils tools you can then use:
+            cangen vcan0
+
+        to create random frames on vcan0 and:
+            candump vcan0 vcan1
+
+        to show data from both busses to see that the messages end up on vcan1 as well.
+        
+    -->
     <node pkg="socketcan_bridge" type="socketcan_to_topic_node" name="socketcan_to_topic_node" output="screen">
         <param name="can_device" value="vcan0" />
     </node>

--- a/socketcan_bridge/test/vcan0_to_vcan1.launch
+++ b/socketcan_bridge/test/vcan0_to_vcan1.launch
@@ -1,0 +1,10 @@
+<launch>
+    
+    <node pkg="socketcan_bridge" type="socketcan_to_topic_node" name="socketcan_to_topic_node" output="screen">
+        <param name="can_device" value="vcan0" />
+    </node>
+    <node pkg="socketcan_bridge" type="topic_to_socketcan_node" name="topic_to_socketcan_node" output="screen">
+          <param name="can_device" value="vcan1" />
+          <remap from="sent_messages" to="received_messages" />
+    </node>
+</launch>

--- a/socketcan_interface/include/socketcan_interface/dummy.h
+++ b/socketcan_interface/include/socketcan_interface/dummy.h
@@ -8,10 +8,12 @@
 
 namespace can{
 
-class DummyInterface : public CommInterface{
+class DummyInterface : public DriverInterface{
     typedef FilteredDispatcher<const unsigned int, CommInterface::FrameListener> FrameDispatcher;
+    typedef FilteredDispatcher<const unsigned int, StateInterface::StateListener> StateDispatcher;
     typedef boost::unordered_multimap<std::string, Frame> Map;
     FrameDispatcher frame_dispatcher_;
+    StateDispatcher state_dispatcher_;
     Map map_;
     const bool loopback_;
 
@@ -56,6 +58,25 @@ public:
     virtual FrameListener::Ptr createMsgListener(const Frame::Header&h , const FrameDelegate &delegate){
         return frame_dispatcher_.createListener(h, delegate);
     }
+
+    // methods from StateInterface
+    virtual bool recover(){return false;};
+
+    virtual State getState(){can::State s; return s;};
+
+    virtual void shutdown(){};
+
+    virtual bool translateError(unsigned int internal_error, std::string & str){return false;};
+
+    virtual bool doesLoopBack() const {return false;};
+
+    virtual void run(){};
+
+    bool init(const std::string &device, bool loopback){return true;};
+
+    virtual StateListener::Ptr createStateListener(const StateDelegate &delegate){
+      return state_dispatcher_.createListener(delegate); // untested
+    };
 
 };
 


### PR DESCRIPTION
Currently there is no package available in ROS to expose can frames from SocketCAN to a topic or the other way around. This pull request contains the additions which provide this functionality, the development has been discussed in issue #137.

It adds the `can_msgs` package, which holds a message type for a CAN Frame. The `socketcan_bridge` package contains nodes and classes that can bridge frames from SocketCAN to a ROS Topic and vice versa. 

The `socketcan_bridge` builds on the `socketcan_interface` package and does not depend on other `ros_canopen` packages. One change to `socketcan_interface` was required: the `DummyInterface` has been modified in order to facilitate testing the `socketcan_bridge` functionality, test results are unaffected by the changes.

Please review the code, if there are any obstacles to the merge, please let me know. I'll write the wiki pages and send an announcement on the ros-users list when the time comes.
