### PR TITLE
Use fixed control period per default

### DIFF
--- a/canopen_motor_node/include/canopen_motor_node/robot_layer.h
+++ b/canopen_motor_node/include/canopen_motor_node/robot_layer.h
@@ -237,10 +237,11 @@ class ControllerManagerLayer : public canopen::Layer {
 
     canopen::time_point last_time_;
     boost::atomic<bool> recover_;
+    const ros::Duration fixed_period_;
 
 public:
-    ControllerManagerLayer(const boost::shared_ptr<RobotLayer> robot, const ros::NodeHandle &nh)
-    :Layer("ControllerManager"), robot_(robot), nh_(nh) {
+    ControllerManagerLayer(const boost::shared_ptr<RobotLayer> robot, const ros::NodeHandle &nh, const ros::Duration &fixed_period)
+    :Layer("ControllerManager"), robot_(robot), nh_(nh), fixed_period_(fixed_period) {
     }
 
     virtual void handleRead(canopen::LayerStatus &status, const LayerState &current_state);

--- a/canopen_motor_node/src/control_node.cpp
+++ b/canopen_motor_node/src/control_node.cpp
@@ -85,7 +85,13 @@ public:
     virtual bool setup() {
         motors_.reset( new LayerGroupNoDiag<MotorBase>("402 Layer"));
         robot_layer_.reset( new RobotLayer(nh_));
-        cm_.reset(new ControllerManagerLayer(robot_layer_, nh_));
+
+        ros::Duration dur(0.0) ;
+        if(!nh_.param("use_realtime_period", false)){
+            dur.fromSec(boost::chrono::duration<double>(update_duration_).count());
+        }
+
+        cm_.reset(new ControllerManagerLayer(robot_layer_, nh_, dur));
 
         if(RosChain::setup()){
             add(motors_);

--- a/canopen_motor_node/src/control_node.cpp
+++ b/canopen_motor_node/src/control_node.cpp
@@ -87,8 +87,12 @@ public:
         robot_layer_.reset( new RobotLayer(nh_));
 
         ros::Duration dur(0.0) ;
+
         if(!nh_.param("use_realtime_period", false)){
             dur.fromSec(boost::chrono::duration<double>(update_duration_).count());
+            ROS_INFO_STREAM("Using fixed control period: " << dur);
+        }else{
+            ROS_INFO("Using real-time control period");
         }
 
         cm_.reset(new ControllerManagerLayer(robot_layer_, nh_, dur));

--- a/canopen_motor_node/src/robot_layer.cpp
+++ b/canopen_motor_node/src/robot_layer.cpp
@@ -428,6 +428,7 @@ void ControllerManagerLayer::handleInit(canopen::LayerStatus &status) {
         status.warn("controller_manager is already intialized");
     }else{
         recover_ = true;
+        last_time_ = canopen::get_abs_time();
         cm_.reset(new controller_manager::ControllerManager(robot_.get(), nh_));
     }
 }

--- a/canopen_motor_node/src/robot_layer.cpp
+++ b/canopen_motor_node/src/robot_layer.cpp
@@ -413,7 +413,12 @@ void ControllerManagerLayer::handleWrite(canopen::LayerStatus &status, const Lay
             canopen::time_point abs_now = canopen::get_abs_time();
             ros::Time now = ros::Time::now();
 
-            ros::Duration period(boost::chrono::duration<double>(abs_now -last_time_).count());
+            ros::Duration period = fixed_period_;
+
+            if(period.isZero()) {
+                period.fromSec(boost::chrono::duration<double>(abs_now -last_time_).count());
+            }
+
             last_time_ = abs_now;
 
             bool recover = recover_.exchange(false);


### PR DESCRIPTION
On non-real-time systems the calculated control period might fluctuate a lot and is sensible prediction for the next control cycle.

The patch uses the update period (which defaults to the sync period) as control period.
The former behaviour can be restored by setting `use_realtime_period` to true.
However, this is not recommended in general.

Closes #165 
