### PR TITLE
added filter chain for state values

### DIFF
--- a/canopen_motor_node/CMakeLists.txt
+++ b/canopen_motor_node/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED
     canopen_chain_node
     controller_manager
     controller_manager_msgs
+    filters
     hardware_interface
     joint_limits_interface
     joint_limits_interface

--- a/canopen_motor_node/include/canopen_motor_node/robot_layer.h
+++ b/canopen_motor_node/include/canopen_motor_node/robot_layer.h
@@ -177,6 +177,8 @@ public:
     hardware_interface::JointHandle* registerHandle(hardware_interface::VelocityJointInterface &iface);
     hardware_interface::JointHandle* registerHandle(hardware_interface::EffortJointInterface &iface);
 
+    bool prepareFilters(canopen::LayerStatus &status);
+
 private:
     virtual void handleRead(canopen::LayerStatus &status, const LayerState &current_state);
     virtual void handleWrite(canopen::LayerStatus &status, const LayerState &current_state);

--- a/canopen_motor_node/include/canopen_motor_node/robot_layer.h
+++ b/canopen_motor_node/include/canopen_motor_node/robot_layer.h
@@ -8,7 +8,7 @@
 #include <joint_limits_interface/joint_limits_interface.h>
 #include <urdf/model.h>
 #include <canopen_402/base.h>
-
+#include <filters/filter_chain.h>
 #include <boost/function.hpp>
 #include <boost/scoped_ptr.hpp>
 
@@ -124,6 +124,9 @@ class HandleLayer: public canopen::Layer{
     ObjectVariables variables_;
     boost::scoped_ptr<UnitConverter>  conv_target_pos_, conv_target_vel_, conv_target_eff_;
     boost::scoped_ptr<UnitConverter>  conv_pos_, conv_vel_, conv_eff_;
+
+    filters::FilterChain<double> filter_pos_, filter_vel_, filter_eff_;
+    XmlRpc::XmlRpcValue options_;
 
     hardware_interface::JointStateHandle jsh_;
     hardware_interface::JointHandle jph_, jvh_, jeh_;

--- a/canopen_motor_node/package.xml
+++ b/canopen_motor_node/package.xml
@@ -19,6 +19,7 @@
   <depend>canopen_chain_node</depend>
   <depend>controller_manager</depend>
   <depend>controller_manager_msgs</depend>
+  <depend>filters</depend>
   <depend>hardware_interface</depend>
   <depend>joint_limits_interface</depend>
   <depend>muparser</depend>

--- a/canopen_motor_node/src/control_node.cpp
+++ b/canopen_motor_node/src/control_node.cpp
@@ -73,6 +73,13 @@ class MotorChain : public RosChain{
         logger->add(motor);
 
         boost::shared_ptr<HandleLayer> handle( new HandleLayer(joint, motor, node->getStorage(), params));
+
+        canopen::LayerStatus s;
+        if(!handle->prepareFilters(s)){
+            ROS_ERROR_STREAM(s.reason());
+            return false;
+        }
+
         robot_layer_->add(joint, handle);
         logger->add(handle);
 

--- a/canopen_motor_node/src/robot_layer.cpp
+++ b/canopen_motor_node/src/robot_layer.cpp
@@ -189,6 +189,12 @@ bool prepareFilter(const std::string& joint_name, const std::string& filter_name
     return true;
 }
 
+bool HandleLayer::prepareFilters(canopen::LayerStatus &status){
+    return prepareFilter(jsh_.getName(), "position_filters", filter_pos_, options_, status) &&
+       prepareFilter(jsh_.getName(), "velocity_filters", filter_vel_, options_, status) &&
+       prepareFilter(jsh_.getName(), "effort_filters", filter_eff_, options_, status);
+}
+
 void HandleLayer::handleInit(LayerStatus &status){
     // TODO: implement proper init
     conv_pos_->reset();
@@ -199,9 +205,7 @@ void HandleLayer::handleInit(LayerStatus &status){
     conv_target_eff_->reset();
 
 
-    if(prepareFilter(jsh_.getName(), "position_filters", filter_pos_, options_, status) &&
-       prepareFilter(jsh_.getName(), "velocity_filters", filter_vel_, options_, status) &&
-       prepareFilter(jsh_.getName(), "effort_filters", filter_eff_, options_, status))
+    if(prepareFilters(status))
     {
         handleRead(status, Layer::Ready);
     }


### PR DESCRIPTION
Adds support for filter chains (http://wiki.ros.org/filters) that get applied after unit conversion.

Example config:

``` yaml
nodes:
  rig1_plate_joint:
    ...
    velocity_filters: # or in defaults
    - type: filters/MeanFilterDouble
      name: my_filter
      params:
        number_of_observations: 3
```
