### PR TITLE
Do not remove shared memory automatically

### DIFF
--- a/canopen_master/include/canopen_master/master.h
+++ b/canopen_master/include/canopen_master/master.h
@@ -279,18 +279,13 @@ public:
 class SharedMaster: public Master{
     // TODO: test multi chain 
     const std::string name_;
-    struct Remover{
-        const std::string name;
-        Remover(const std::string &n) : name(n) {  boost::interprocess::shared_memory_object::remove(name.c_str()); }
-        ~Remover(){  boost::interprocess::shared_memory_object::remove(name.c_str()); }
-    } remover_;
     boost::interprocess::managed_shared_memory managed_shm_;
     boost::mutex mutex_;
     boost::unordered_map<can::Header, boost::shared_ptr<SharedIPCSyncMaster> > syncmasters_;
     boost::shared_ptr<can::CommInterface> interface_;
 public:
     SharedMaster(const std::string &name, boost::shared_ptr<can::CommInterface> interface, const boost::interprocess::permissions & perm = boost::interprocess::permissions())
-    : name_("canopen_master_shm_"+name), remover_(name_.c_str()),
+    : name_("canopen_master_shm_"+name),
         managed_shm_(boost::interprocess::open_or_create, name_.c_str(), 4096, 0, perm),
         interface_(interface)  {}
     virtual boost::shared_ptr<SyncLayer> getSync(const SyncProperties &properties);


### PR DESCRIPTION
Addresses issues with concurrent node restarts.
related to #71 
