### PR TITLE
protect MotorChain setup with RosChain lock

### DIFF
--- a/canopen_chain_node/include/canopen_chain_node/ros_chain.h
+++ b/canopen_chain_node/include/canopen_chain_node/ros_chain.h
@@ -194,9 +194,10 @@ protected:
     bool setup_nodes();
     virtual bool nodeAdded(XmlRpc::XmlRpcValue &params, const boost::shared_ptr<canopen::Node> &node, const boost::shared_ptr<Logger> &logger);
     void report_diagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat);
+    virtual bool setup_chain();
 public:
     RosChain(const ros::NodeHandle &nh, const ros::NodeHandle &nh_priv);
-    virtual bool setup();
+    bool setup();
     virtual ~RosChain();
 };
 

--- a/canopen_chain_node/src/ros_chain.cpp
+++ b/canopen_chain_node/src/ros_chain.cpp
@@ -470,7 +470,10 @@ RosChain::RosChain(const ros::NodeHandle &nh, const ros::NodeHandle &nh_priv)
 
 bool RosChain::setup(){
     boost::mutex::scoped_lock lock(mutex_);
+    return setup_chain();
+}
 
+bool RosChain::setup_chain(){
     std::string hw_id;
     nh_priv_.param("hardware_id", hw_id, std::string("none"));
 

--- a/canopen_motor_node/src/control_node.cpp
+++ b/canopen_motor_node/src/control_node.cpp
@@ -89,13 +89,13 @@ class MotorChain : public RosChain{
 public:
     MotorChain(const ros::NodeHandle &nh, const ros::NodeHandle &nh_priv): RosChain(nh, nh_priv), motor_allocator_("canopen_402", "canopen::MotorBase::Allocator"){}
 
-    virtual bool setup() {
+    virtual bool setup_chain() {
         motors_.reset( new LayerGroupNoDiag<MotorBase>("402 Layer"));
         robot_layer_.reset( new RobotLayer(nh_));
 
         ros::Duration dur(0.0) ;
 
-        if(RosChain::setup()){
+        if(RosChain::setup_chain()){
             add(motors_);
             add(robot_layer_);
 
@@ -116,7 +116,7 @@ public:
 };
 
 int main(int argc, char** argv){
-  ros::init(argc, argv, "canopen_chain_node_node");
+  ros::init(argc, argv, "canopen_motor_chain_node");
   ros::AsyncSpinner spinner(0);
   spinner.start();
 


### PR DESCRIPTION
Should fix #181 

`setup` is replaced by mutex-protected `setup_chain`.

@mistoll: please review
