### PR TITLE
Added support for external sync providers

### DIFF
--- a/canopen_chain_node/CMakeLists.txt
+++ b/canopen_chain_node/CMakeLists.txt
@@ -62,10 +62,20 @@ target_link_libraries(canopen_chain_node
   ${catkin_LIBRARIES}
 )
 
+# canopen_sync_node
+add_executable(canopen_sync_node
+  src/sync_node.cpp
+)
+target_link_libraries(canopen_sync_node
+  ${Boost_LIBRARIES}
+  ${catkin_LIBRARIES}
+)
+
 install(
   TARGETS
     canopen_chain_node
     canopen_ros_chain
+    canopen_sync_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/canopen_chain_node/src/ros_chain.cpp
+++ b/canopen_chain_node/src/ros_chain.cpp
@@ -223,6 +223,9 @@ bool RosChain::setup_bus(){
 
     bus_nh.param("master_allocator",master_alloc, std::string("canopen::SimpleMaster::Allocator"));
 
+    if(master_alloc == "canopen::LocalMaster::Allocator" || master_alloc == "canopen::SharedMaster::Allocator" || master_alloc == "canopen::UnrestrictedMaster::Allocator"){
+        ROS_WARN_STREAM(master_alloc << " is going be removed, please consider using canopen::ExternalMaster::Allocator in combination with canopen_chain_sync");
+    }
     try{
         master_= master_allocator_.allocateInstance(master_alloc, can_device, interface_);
     }

--- a/canopen_chain_node/src/ros_chain.cpp
+++ b/canopen_chain_node/src/ros_chain.cpp
@@ -63,9 +63,10 @@ void RosChain::run(){
         catch(const canopen::Exception& e){
             ROS_ERROR_STREAM_THROTTLE(1, boost::diagnostic_information(e));
         }
-        abs_time += update_duration_;
-
-        boost::this_thread::sleep_until(abs_time);
+        if(!sync_){
+            abs_time += update_duration_;
+            boost::this_thread::sleep_until(abs_time);
+        }
     }
 }
 

--- a/canopen_chain_node/src/sync_node.cpp
+++ b/canopen_chain_node/src/sync_node.cpp
@@ -1,0 +1,100 @@
+#include <canopen_master/bcm_sync.h>
+#include <socketcan_interface/string.h>
+#include <canopen_master/can_layer.h>
+#include <ros/ros.h>
+#include <diagnostic_updater/diagnostic_updater.h>
+
+template<typename T > std::string join(const T &container, const std::string &delim){
+    if(container.empty()) return std::string();
+    std::stringstream sstr;
+    typename T::const_iterator it = container.begin();
+    sstr << *it;
+    for(++it; it != container.end(); ++it){
+        sstr << delim << *it;
+    }
+    return sstr.str();
+}
+void report_diagnostics(canopen::LayerStack &sync, diagnostic_updater::DiagnosticStatusWrapper &stat){
+    canopen::LayerReport r;
+    sync.read(r);
+    sync.diag(r);
+    if(sync.getLayerState() !=canopen::Layer::Off  &&  r.bounded<canopen::LayerStatus::Unbounded>()){ // valid
+        stat.summary(r.get(), r.reason());
+        for(std::vector<std::pair<std::string, std::string> >::const_iterator it = r.values().begin(); it != r.values().end(); ++it){
+            stat.add(it->first, it->second);
+        }
+        if(!r.bounded<canopen::LayerStatus::Warn>()){
+            canopen::LayerStatus s;
+            sync.recover(s);
+        }
+    }else{
+        stat.summary(stat.WARN, "sync not initilized");
+        canopen::LayerStatus s;
+        sync.init(s);
+    }
+}
+
+int main(int argc, char** argv){
+    ros::init(argc, argv, "canopen_sync_node");
+
+    ros::NodeHandle nh;
+    ros::NodeHandle nh_priv("~");
+
+    ros::NodeHandle sync_nh(nh_priv, "sync");
+    int sync_ms;
+    if(!sync_nh.getParam("interval_ms", sync_ms) || sync_ms <=0){
+        ROS_ERROR_STREAM("Sync interval  "<< sync_ms << " is invalid");
+        return false;
+    }
+
+    int sync_overflow = 0;
+    if(!sync_nh.getParam("overflow", sync_overflow)){
+        ROS_WARN("Sync overflow was not specified, so overflow is disabled per default");
+    }
+    if(sync_overflow == 1 || sync_overflow > 240){
+        ROS_ERROR_STREAM("Sync overflow  "<< sync_overflow << " is invalid");
+        return false;
+    }
+
+
+    std::string can_device;
+    if(!nh_priv.getParam("bus/device",can_device)){
+        ROS_ERROR("Device not set");
+        return 1;
+    }
+
+    boost::shared_ptr<can::SocketCANDriver> driver = boost::make_shared<can::SocketCANDriver>();
+    canopen::SyncProperties sync_properties(can::MsgHeader(sync_nh.param("sync_id", 0x080)), sync_ms, sync_overflow);
+
+    boost::shared_ptr<canopen::BCMsync> sync = boost::make_shared<canopen::BCMsync>(can_device, driver, sync_properties);
+
+    std::vector<int> nodes;
+
+    if(sync_nh.getParam("monitored_nodes",nodes)){
+        sync->setMonitored(nodes);
+    }else{
+        std::string msg;
+        if(nh_priv.getParam("heartbeat/msg", msg)){
+            can::Frame f = can::toframe(msg);
+            if(f.isValid() && (f.id & ~canopen::BCMsync::ALL_NODES_MASK) == canopen::BCMsync::HEARTBEAT_ID){
+                nodes.push_back(f.id & canopen::BCMsync::ALL_NODES_MASK);
+            }
+        }
+        sync_nh.getParam("ignored_nodes",nodes);
+        sync->setIgnored(nodes);
+    }
+
+    canopen::LayerStack stack("SyncNodeLayer");
+
+    stack.add(boost::make_shared<canopen::CANLayer>(driver, can_device, false));
+    stack.add(sync);
+
+    diagnostic_updater::Updater diag_updater(nh, nh_priv);
+    diag_updater.setHardwareID(nh_priv.param("hardware_id", std::string("none")));
+    diag_updater.add("sync", boost::bind(report_diagnostics,boost::ref(stack), _1));
+
+    ros::Timer diag_timer = nh.createTimer(ros::Duration(diag_updater.getPeriod()/2.0),boost::bind(&diagnostic_updater::Updater::update, &diag_updater));
+
+    ros::spin();
+    return 0;
+}

--- a/canopen_master/CMakeLists.txt
+++ b/canopen_master/CMakeLists.txt
@@ -48,8 +48,19 @@ target_link_libraries(canopen_master_plugin
   ${Boost_LIBRARIES}
   canopen_master
 )
+
+# canopen_bcm_sync
+add_executable(canopen_bcm_sync
+  src/bcm_sync.cpp
+)
+target_link_libraries(canopen_bcm_sync
+  ${Boost_LIBRARIES}
+  ${catkin_LIBRARIES}
+)
+
 install(
   TARGETS
+    canopen_bcm_sync
     canopen_master
     canopen_master_plugin
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/canopen_master/include/canopen_master/bcm_sync.h
+++ b/canopen_master/include/canopen_master/bcm_sync.h
@@ -1,0 +1,167 @@
+#ifndef H_BCM_SYNC
+#define H_BCM_SYNC
+
+#include <socketcan_interface/bcm.h>
+#include <socketcan_interface/socketcan.h>
+#include <canopen_master/canopen.h>
+
+namespace canopen {
+
+template<typename T > std::string join(const T &container, const std::string &delim){
+    if(container.empty()) return std::string();
+    std::stringstream sstr;
+    typename T::const_iterator it = container.begin();
+    sstr << *it;
+    for(++it; it != container.end(); ++it){
+        sstr << delim << *it;
+    }
+    return sstr.str();
+}
+
+class BCMsync : public Layer {
+    boost::mutex mutex_;
+
+    std::string device_;
+
+    std::set<int> ignored_nodes_;
+    std::set<int> monitored_nodes_;
+    std::set<int> known_nodes_;
+    std::set<int> started_nodes_;
+
+    bool sync_running_;
+    can::BCMsocket bcm_;
+    boost::shared_ptr<can::SocketCANDriver>  driver_;
+    uint16_t sync_ms_;
+    can::CommInterface::FrameListener::Ptr handler_;
+
+    std::vector<can::Frame> sync_frames_;
+
+    bool skipNode(uint8_t id){
+        if(ignored_nodes_.find(id) != ignored_nodes_.end()) return true;
+        if(!monitored_nodes_.empty() && monitored_nodes_.find(id) == monitored_nodes_.end()) return true;
+        known_nodes_.insert(id);
+        return false;
+    }
+
+    void handleFrame(const can::Frame &frame){
+        boost::mutex::scoped_lock lock(mutex_);
+
+        if(frame.id == NMT_ID){
+            if(frame.dlc > 1){
+                uint8_t cmd = frame.data[0];
+                uint8_t id = frame.data[1];
+                if(skipNode(id)) return;
+
+                if(cmd == 1){ // started
+                    if(id != 0) started_nodes_.insert(id);
+                    else started_nodes_.insert(known_nodes_.begin(), known_nodes_.end()); // start all
+                }else{
+                    if(id != 0) started_nodes_.erase(id);
+                    else started_nodes_.clear(); // stop all
+                }
+            }
+        }else if((frame.id & ~ALL_NODES_MASK) == HEARTBEAT_ID){
+            int id = frame.id & ALL_NODES_MASK;
+            if(skipNode(id)) return;
+
+            if(frame.dlc > 0 && frame.data[0] ==  canopen::Node::Stopped) started_nodes_.erase(id); 
+        }
+
+        // toggle sync if needed
+        if(started_nodes_.empty() && sync_running_){
+            sync_running_ = !bcm_.stopTX(sync_frames_.front());
+        }else if(!started_nodes_.empty() && !sync_running_){
+            sync_running_ = bcm_.startTX(boost::chrono::milliseconds(sync_ms_),sync_frames_.front(), sync_frames_.size(), &sync_frames_[0]);
+        }
+    }
+protected:
+    virtual void handleRead(LayerStatus &status, const LayerState &current_state) {
+        if(current_state > Init){
+        }
+    }
+    virtual void handleWrite(LayerStatus &status, const LayerState &current_state) {
+        if(current_state > Init){
+        }
+    }
+    virtual void handleDiag(LayerReport &report){
+        boost::mutex::scoped_lock lock(mutex_);
+        if(!sync_running_) report.warn("sync is not running");
+
+        report.add("sync_running", sync_running_);
+        report.add("known_nodes", join(known_nodes_, ", "));
+        report.add("started_nodes", join(started_nodes_, ", "));
+    }
+ 
+    virtual void handleInit(LayerStatus &status){
+        boost::mutex::scoped_lock lock(mutex_);
+        started_nodes_.clear();
+
+        if(!bcm_.init(device_)){
+            status.error("BCM_init failed");
+            return;
+        }
+        int sc = driver_->getInternalSocket();
+
+        struct can_filter filter[2];
+
+        filter[0].can_id   = NMT_ID;
+        filter[0].can_mask = CAN_SFF_MASK;
+        filter[1].can_id   = HEARTBEAT_ID;
+        filter[1].can_mask =  ~ALL_NODES_MASK;
+
+        if(setsockopt(sc, SOL_CAN_RAW, CAN_RAW_FILTER, &filter, sizeof(filter)) < 0){
+            status.warn("could not set filter");
+            return;
+        }
+
+        handler_ = driver_->createMsgListener(can::CommInterface::FrameDelegate(this, &BCMsync::handleFrame));
+    }
+    virtual void handleShutdown(LayerStatus &status){
+        boost::mutex::scoped_lock lock(mutex_);
+        handler_.reset();
+        bcm_.shutdown();
+    }
+
+    virtual void handleHalt(LayerStatus &status) {
+        boost::mutex::scoped_lock lock(mutex_);
+        if(sync_running_){
+            bcm_.stopTX(sync_frames_.front());        
+            sync_running_ = false;
+            started_nodes_.clear();
+        }
+    }
+
+    virtual void handleRecover(LayerStatus &status){
+        handleShutdown(status);
+        handleInit(status);
+    }
+public:
+    static const uint32_t ALL_NODES_MASK = 127;
+    static const uint32_t HEARTBEAT_ID = 0x700;
+    static const uint32_t NMT_ID = 0x000;
+
+    BCMsync(const std::string &device, boost::shared_ptr<can::SocketCANDriver>  driver, const SyncProperties &sync_properties)
+    : Layer(device + " SyncLayer"), device_(device), sync_running_(false), sync_ms_(sync_properties.period_ms_), driver_(driver) {
+        if(sync_properties.overflow_ == 0){
+            sync_frames_.resize(1);
+            sync_frames_[0] = can::Frame(sync_properties.header_,0);
+        }else{
+            sync_frames_.resize(sync_properties.overflow_);
+            for(int i = 0; i < sync_properties.overflow_; ++i){
+                sync_frames_[i] = can::Frame(sync_properties.header_,1);
+                sync_frames_[i].data[0] = i+1;
+            }
+        }
+    }
+    template <class T> void setMonitored(const T &other){
+        monitored_nodes_.clear();
+        monitored_nodes_.insert(other.begin(), other.end());
+    }
+    template <class T> void setIgnored(const T &other){
+        ignored_nodes_.clear();
+        ignored_nodes_.insert(other.begin(), other.end());
+    }
+};
+
+}
+#endif

--- a/canopen_master/master_plugin.xml
+++ b/canopen_master/master_plugin.xml
@@ -11,4 +11,7 @@
   <class type="canopen::SimpleMaster::Allocator" base_class_type="canopen::Master::Allocator">
     <description>Allocator for SimpleMaster instances</description>
   </class>
+  <class type="canopen::ExternalMaster::Allocator" base_class_type="canopen::Master::Allocator">
+    <description>Allocator for ExternalMaster instances</description>
+  </class>
 </library>

--- a/canopen_master/src/bcm_sync.cpp
+++ b/canopen_master/src/bcm_sync.cpp
@@ -1,0 +1,67 @@
+#include <canopen_master/bcm_sync.h>
+#include <socketcan_interface/string.h>
+
+int main(int argc, char** argv){
+
+    if(argc < 4){
+        std::cout << "Usage: " << argv[0] << " DEVICE PERIOD_MS HEADER [OVERFLOW] [+ID*] [-ID*] [--]" << std::endl;
+        return 1;
+    }
+
+    std::string can_device = argv[1];
+    int sync_ms = atoi(argv[2]);
+    can::Header header = can::toheader(argv[3]);
+
+    if(!header.isValid()){
+            std::cout << "header is invalid" << std::endl;
+            return 1;
+    }
+    int sync_overflow = 0;
+
+    int start = 4;
+    if(argc > start && argv[start][0] != '-' && argv[start][0] != '+'){
+        sync_overflow = atoi(argv[4]);
+        if(sync_overflow == 1 || sync_overflow < 0 || sync_overflow > 240){
+            std::cout << "sync overflow is invalid" << std::endl;
+            return 1;
+        }
+        ++start;
+    }
+
+    std::set<int> monitored, ignored;
+
+    for(; argc > start; ++start){
+        if(strncmp("--", argv[start], 2) == 0) break;
+        int id = atoi(argv[start]);
+
+        if(id > 0 && id < 128) monitored.insert(id);
+        else if (id < 0 && id > -128) ignored.insert(-id);
+        else{
+            std::cout << "ID is invalid: " << id  << std::endl;
+            return 1;
+        }
+    }
+
+    boost::shared_ptr<can::SocketCANDriver> driver = boost::make_shared<can::SocketCANDriver>();
+    if(!driver->init(can_device, false)){
+        std::cout << "Could not initialize CAN" << std::endl;
+        return 1;
+    }
+
+    canopen::SyncProperties sync_properties(header, sync_ms, sync_overflow);
+    canopen::BCMsync sync(can_device, driver, sync_properties);
+
+    sync.setMonitored(monitored);
+    sync.setIgnored(ignored);
+
+    canopen::LayerStatus status;
+    sync.init(status);
+    if(!status.bounded<canopen::LayerStatus::Warn>()){
+        std::cout << "Could not initialize sync" << std::endl;
+        return 1;
+    }
+    
+    driver->run();
+
+    return 0;
+}

--- a/canopen_master/src/master_plugin.cpp
+++ b/canopen_master/src/master_plugin.cpp
@@ -1,17 +1,48 @@
 #include <class_loader/class_loader.h>
 #include <canopen_master/master.h>
+#include <socketcan_interface/reader.h>
 
 #include <set>
 
 namespace canopen {
-class SimpleSyncLayer: public SyncLayer {
+
+class ManagingSyncLayer: public SyncLayer {
+protected:
     boost::shared_ptr<can::CommInterface> interface_;
-    time_point read_time_, write_time_;
     boost::chrono::milliseconds step_, half_step_;
 
     std::set<void *> nodes_;
     boost::mutex nodes_mutex_;
     boost::atomic<size_t> nodes_size_;
+    
+    virtual void handleShutdown(LayerStatus &status) {
+    }
+
+    virtual void handleHalt(LayerStatus &status)  { /* nothing to do */ }
+    virtual void handleDiag(LayerReport &report)  { /* TODO */ }
+    virtual void handleRecover(LayerStatus &status)  { /* TODO */ }
+
+public:
+    ManagingSyncLayer(const SyncProperties &p, boost::shared_ptr<can::CommInterface> interface)
+    : SyncLayer(p), interface_(interface), step_(p.period_ms_), half_step_(p.period_ms_/2), nodes_size_(0)
+    {
+    }
+
+    virtual void addNode(void * const ptr) {
+        boost::mutex::scoped_lock lock(nodes_mutex_);
+        nodes_.insert(ptr);
+        nodes_size_ = nodes_.size();
+    }
+    virtual void removeNode(void * const ptr)  {
+        boost::mutex::scoped_lock lock(nodes_mutex_);
+        nodes_.erase(ptr);
+        nodes_size_ = nodes_.size();
+    }
+};
+
+    
+class SimpleSyncLayer: public ManagingSyncLayer {
+    time_point read_time_, write_time_;
 protected:
     virtual void handleRead(LayerStatus &status, const LayerState &current_state) {
         if(current_state > Init){
@@ -34,48 +65,53 @@ protected:
         write_time_ = get_abs_time(step_);
         read_time_ = get_abs_time(half_step_);
     }
-    virtual void handleShutdown(LayerStatus &status) {
-    }
-
-    virtual void handleHalt(LayerStatus &status)  { /* nothing to do */ }
-    virtual void handleDiag(LayerReport &report)  { /* TODO */ }
-    virtual void handleRecover(LayerStatus &status)  { /* TODO */ }
-
 public:
     SimpleSyncLayer(const SyncProperties &p, boost::shared_ptr<can::CommInterface> interface)
-    : SyncLayer(p), interface_(interface), step_(p.period_ms_), half_step_(p.period_ms_/2), nodes_size_(0)
-    {
-    }
-
-    virtual void addNode(void * const ptr) {
-        boost::mutex::scoped_lock lock(nodes_mutex_);
-        nodes_.insert(ptr);
-        nodes_size_ = nodes_.size();
-    }
-    virtual void removeNode(void * const ptr)  {
-        boost::mutex::scoped_lock lock(nodes_mutex_);
-        nodes_.erase(ptr);
-        nodes_size_ = nodes_.size();
-    }
+    : ManagingSyncLayer(p, interface) {}
 };
-class SimpleMaster: public Master{
+
+class ExternalSyncLayer: public ManagingSyncLayer {
+    can::BufferedReader reader_;
+protected:
+    virtual void handleRead(LayerStatus &status, const LayerState &current_state) {
+        can::Frame msg;
+        if(current_state > Init){
+            if(reader_.readUntil(&msg, get_abs_time(step_))){ // wait for sync
+                boost::this_thread::sleep_until(get_abs_time(half_step_)); // shift readout to middle of period
+            }
+        }
+    }
+    virtual void handleWrite(LayerStatus &status, const LayerState &current_state) {
+        // nothing to do here
+    }
+    virtual void handleInit(LayerStatus &status){
+        reader_.listen(interface_, can::MsgHeader(properties.header_));
+    }
+public:
+    ExternalSyncLayer(const SyncProperties &p, boost::shared_ptr<can::CommInterface> interface)
+    : ManagingSyncLayer(p, interface), reader_(true,1) {}
+};
+
+
+template<typename SyncType> class WrapMaster: public Master{
     boost::shared_ptr<can::CommInterface> interface_;
 public:
     virtual boost::shared_ptr<SyncLayer> getSync(const SyncProperties &properties){
-        return boost::make_shared<SimpleSyncLayer>(properties, interface_);
+        return boost::make_shared<SyncType>(properties, interface_);
     }
-    SimpleMaster(boost::shared_ptr<can::CommInterface> interface) : interface_(interface)  {}
+    WrapMaster(boost::shared_ptr<can::CommInterface> interface) : interface_(interface)  {}
 
     class Allocator : public Master::Allocator{
     public:
         virtual boost::shared_ptr<Master> allocate(const std::string &name,  boost::shared_ptr<can::CommInterface> interface){
-            return boost::make_shared<canopen::SimpleMaster>(interface);
+            return boost::make_shared<WrapMaster>(interface);
         }
     };
 };
 
+typedef WrapMaster<SimpleSyncLayer> SimpleMaster;
+typedef WrapMaster<ExternalSyncLayer> ExternalMaster;
 }
-
 boost::shared_ptr<canopen::Master> canopen::LocalMaster::Allocator::allocate(const std::string &name, boost::shared_ptr<can::CommInterface> interface) {
     return boost::make_shared<canopen::LocalMaster>(interface);
 }
@@ -91,3 +127,5 @@ CLASS_LOADER_REGISTER_CLASS(canopen::LocalMaster::Allocator, canopen::Master::Al
 CLASS_LOADER_REGISTER_CLASS(canopen::SharedMaster::Allocator, canopen::Master::Allocator);
 CLASS_LOADER_REGISTER_CLASS(canopen::UnrestrictedMaster::Allocator, canopen::Master::Allocator);
 CLASS_LOADER_REGISTER_CLASS(canopen::SimpleMaster::Allocator, canopen::Master::Allocator);
+CLASS_LOADER_REGISTER_CLASS(canopen::ExternalMaster::Allocator, canopen::Master::Allocator);
+

--- a/socketcan_interface/CMakeLists.txt
+++ b/socketcan_interface/CMakeLists.txt
@@ -38,7 +38,19 @@ add_library(socketcan_interface_string
 add_executable(socketcan_dump
   src/candump.cpp
 )
+
 target_link_libraries(socketcan_dump
+   socketcan_interface_string
+   ${catkin_LIBRARIES}
+   ${Boost_LIBRARIES}
+)
+
+# socketcan_bcm
+add_executable(socketcan_bcm
+  src/canbcm.cpp
+)
+
+target_link_libraries(socketcan_bcm
    socketcan_interface_string
    ${catkin_LIBRARIES}
    ${Boost_LIBRARIES}
@@ -55,6 +67,7 @@ target_link_libraries(socketcan_interface_plugin
 
 install(
   TARGETS
+    socketcan_bcm
     socketcan_dump
     socketcan_interface_plugin
     socketcan_interface_string

--- a/socketcan_interface/include/socketcan_interface/asio_base.h
+++ b/socketcan_interface/include/socketcan_interface/asio_base.h
@@ -65,6 +65,7 @@ protected:
             triggerReadSome();
         }else{
             setErrorCode(error);
+            setNotReady();
         }
     }
 

--- a/socketcan_interface/include/socketcan_interface/bcm.h
+++ b/socketcan_interface/include/socketcan_interface/bcm.h
@@ -1,0 +1,116 @@
+#ifndef H_CAN_BCM
+#define H_CAN_BCM
+
+#include <socketcan_interface/interface.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+ 
+#include <linux/can.h>
+#include <linux/can/bcm.h>
+#include <linux/can/error.h>
+
+namespace can {
+
+class BCMsocket{
+    int s_;
+    struct Message {
+        size_t size;
+        uint8_t *data;
+        Message(size_t n)
+        : size(sizeof(bcm_msg_head) + sizeof(can_frame)*n), data(new uint8_t[size])
+        {
+            assert(n<=256);
+            memset(data, 0, size);
+            head().nframes = n;
+        }
+        bcm_msg_head& head() {
+            return *(bcm_msg_head*)data;
+        }
+        template<typename T> void setIVal2(T period){
+            long long usec = boost::chrono::duration_cast<boost::chrono::microseconds>(period).count();
+            head().ival2.tv_sec = usec / 1000000;
+            head().ival2.tv_usec = usec % 1000000;
+        }
+        void setHeader(Header header){
+            head().can_id = header.id | (header.is_extended?CAN_EFF_FLAG:0);
+        }
+        bool write(int s){
+            return ::write(s, data, size) > 0;
+        }
+        ~Message(){
+            delete[] data;
+            data = 0;
+            size = 0;
+        }
+    };
+public:
+    BCMsocket():s_(-1){
+    }
+    bool init(const std::string &device){
+        s_ = socket(PF_CAN, SOCK_DGRAM, CAN_BCM);
+
+        if(s_ < 0 ) return false;
+        struct ifreq ifr;
+        strcpy(ifr.ifr_name, device.c_str());
+        int ret = ioctl(s_, SIOCGIFINDEX, &ifr);
+
+        if(ret != 0){
+            shutdown();
+            return false;
+        }
+
+        struct sockaddr_can addr = {0};
+        addr.can_family = AF_CAN;
+        addr.can_ifindex = ifr.ifr_ifindex;
+
+        ret = connect(s_, (struct sockaddr *)&addr, sizeof(addr));
+
+        if(ret < 0){
+            shutdown();
+            return false;
+        }
+        return true;
+    }
+    template<typename DurationType> bool startTX(DurationType period, Header header, size_t num, Frame *frames) {
+        Message msg(num);
+        msg.setHeader(header);
+        msg.setIVal2(period);
+
+        bcm_msg_head &head = msg.head();
+
+        head.opcode = TX_SETUP;
+        head.flags |= SETTIMER | STARTTIMER;
+
+        for(size_t i=0; i < num; ++i){ // msg nr
+            head.frames[i].can_dlc = frames[i].dlc;
+            head.frames[i].can_id = head.can_id;
+            for(size_t j = 0; j < head.frames[i].can_dlc; ++j){ // byte nr
+                head.frames[i].data[j] = frames[i].data[j];
+            }
+        }
+        return msg.write(s_);
+    }
+    bool stopTX(Header header){
+        Message msg(0);
+        msg.head().opcode = TX_DELETE;
+        msg.setHeader(header);
+        return msg.write(s_);
+    }
+    void shutdown(){
+        if(s_ > 0){
+            close(s_);
+            s_ = -1;
+        }
+    }
+
+    virtual ~BCMsocket(){
+        shutdown();
+    }
+};
+
+}
+
+#endif

--- a/socketcan_interface/include/socketcan_interface/reader.h
+++ b/socketcan_interface/include/socketcan_interface/reader.h
@@ -89,8 +89,10 @@ public:
     }
 
     template<typename DurationType> bool read(can::Frame * msg, const DurationType &duration){
+        return readUntil(msg, boost::chrono::high_resolution_clock::now() + duration);
+    }
+    bool readUntil(can::Frame * msg, boost::chrono::high_resolution_clock::time_point abs_time){
         boost::mutex::scoped_lock lock(mutex_);
-        boost::chrono::high_resolution_clock::time_point abs_time =  boost::chrono::high_resolution_clock::now() + duration;
 
         while(buffer_.empty() && cond_.wait_until(lock,abs_time)  != boost::cv_status::timeout)
         {}
@@ -104,7 +106,6 @@ public:
             buffer_.pop_front();
         }
         return true;
-
     }
 
 };

--- a/socketcan_interface/include/socketcan_interface/socketcan.h
+++ b/socketcan_interface/include/socketcan_interface/socketcan.h
@@ -19,9 +19,10 @@ namespace can {
 
 class SocketCANInterface : public AsioDriver<boost::asio::posix::stream_descriptor> {
     bool loopback_;
+    int sc_;
 public:    
     SocketCANInterface()
-    : loopback_(false)
+    : loopback_(false), sc_(-1)
     {}
     
     virtual bool doesLoopBack() const{
@@ -31,6 +32,7 @@ public:
     virtual bool init(const std::string &device, bool loopback){
         State s = getState();
         if(s.driver_state == State::closed){
+            sc_ = 0;
             device_ = device;
             loopback_ = loopback;
 
@@ -103,6 +105,7 @@ public:
             }
             setInternalError(0);
             setDriverState(State::open);
+            sc_ = sc;
             return true;
         }
         return getState().isReady();
@@ -150,6 +153,9 @@ public:
             ret = true;
         }
         return ret;
+    }
+    int getInternalSocket() {
+        return sc_;
     }
 protected:
     std::string device_;

--- a/socketcan_interface/src/canbcm.cpp
+++ b/socketcan_interface/src/canbcm.cpp
@@ -1,0 +1,39 @@
+#include <socketcan_interface/bcm.h>
+#include <socketcan_interface/string.h>
+
+using namespace can;
+
+#include <iostream>
+
+int main(int argc, char *argv[]){
+    BCMsocket bcm;
+
+    int extra_frames = argc - 4; 
+
+    if(extra_frames < 0){
+        std::cout << "usage: "<< argv[0] << " DEVICE PERIOD HEADER#DATA [DATA*]" << std::endl;
+        return 1;
+    }
+
+    if(!bcm.init(argv[1])){
+        return 2;
+    }
+
+    int num_frames = extra_frames+1;
+    Frame *frames = new Frame[num_frames];
+    Header header = frames[0] = toframe(argv[3]);
+
+    if(extra_frames > 0){
+        for(int i=0; i< extra_frames; ++i){
+            frames[1+i] = toframe(tostring(header,true)+"#"+argv[4+i]);
+        }
+    }
+    for(int i = 0; i < num_frames; ++i){
+        std::cout << frames[i] << std::endl;
+    }
+    if(bcm.startTX(boost::chrono::duration<double>(atof(argv[2])), header, num_frames, frames)){
+        pause();
+        return 0;
+    }
+    return 4;
+}


### PR DESCRIPTION
addresses #71 

This patch contians a new sync plugin (`canopen::ExternalMaster::Allocator`) for external sync sources and a BCM-based sync provider.
The sync provider monitors NMT and Heartbeat messages to decide when to start and stop the sync.

The CAN BCM generates the SYNC in kernel space, so it should have less jitter.

Usage:
```
rosrun canopen_master canopen_bcm_sync DEVICE PERIOD_MS HEADER [OVERFLOW] [+ID*] [-ID*] [--]
```
The `+-ID` option can be used for white/black listing.

As an alternative `canopen_sync_node` with ROS parameter suppport is available (`canopen_chain_node` syntax).