### PR TITLE
Object logging in diagnostics

### DIFF
--- a/canopen_chain_node/include/canopen_chain_node/ros_chain.h
+++ b/canopen_chain_node/include/canopen_chain_node/ros_chain.h
@@ -146,6 +146,7 @@ protected:
     boost::shared_ptr<can::DriverInterface> interface_;
     boost::shared_ptr<Master> master_;
     boost::shared_ptr<canopen::LayerGroupNoDiag<canopen::Node> > nodes_;
+    std::map<std::string, boost::shared_ptr<canopen::Node> > nodes_lookup_;
     boost::shared_ptr<canopen::SyncLayer> sync_;
     std::vector<boost::shared_ptr<Logger > > loggers_;
     std::vector<PublishFunc::func_type> publishers_;

--- a/canopen_chain_node/src/ros_chain.cpp
+++ b/canopen_chain_node/src/ros_chain.cpp
@@ -417,6 +417,8 @@ bool RosChain::setup_nodes(){
         loggers_.push_back(logger);
         diag_updater_.add(it->first, boost::bind(&Logger::log, logger, _1));
 
+        std::string node_name = std::string(merged["name"]);
+        
         if(merged.hasMember("publish")){
             try{
                 XmlRpc::XmlRpcValue objs = merged["publish"];
@@ -426,7 +428,7 @@ bool RosChain::setup_nodes(){
                     bool force = pos != std::string::npos;
                     if(force) obj_name.erase(pos);
 
-                    boost::function<void()> pub = PublishFunc::create(nh_, std::string(merged["name"])+"_"+obj_name, node, obj_name, force);
+                    boost::function<void()> pub = PublishFunc::create(nh_, node_name +"_"+obj_name, node, obj_name, force);
                     if(!pub){
                         ROS_ERROR_STREAM("Could not create publisher for '" << obj_name << "'");
                         return false;
@@ -440,6 +442,7 @@ bool RosChain::setup_nodes(){
             }
         }
         nodes_->add(node);
+        nodes_lookup_.insert(std::make_pair(node_name, node));
     }
     return true;
 }

--- a/canopen_master/include/canopen_master/objdict.h
+++ b/canopen_master/include/canopen_master/objdict.h
@@ -6,6 +6,7 @@
 #include <boost/unordered_set.hpp>    
 #include <boost/thread/mutex.hpp>    
 #include <boost/make_shared.hpp>
+#include <boost/function.hpp>
 #include <typeinfo> 
 #include <vector>
 #include "exceptions.h"
@@ -496,6 +497,7 @@ public:
             return false;
         }
     }
+     boost::function<std::string()> getStringReader(const ObjectDict::Key &key, bool cached = false);
 
     const boost::shared_ptr<const ObjectDict> dict_;
     const uint8_t node_id_;


### PR DESCRIPTION
Refactored existing code for object logging to make it work again.

Each node can take a `log` (all cases) ,`log_warn` (warn and error), or `log_error` (only error) list which adds diagnostics entries.
Syntax is the same as for `publish`, with ! forcing an update.