### PR TITLE
do not call handleReadread in HandleLayer::handleRecover

### DIFF
--- a/canopen_motor_node/include/canopen_motor_node/robot_layer.h
+++ b/canopen_motor_node/include/canopen_motor_node/robot_layer.h
@@ -209,7 +209,7 @@ private:
     virtual void handleDiag(canopen::LayerReport &report) { /* nothing to do */ }
     virtual void handleShutdown(canopen::LayerStatus &status) { /* nothing to do */ }
     virtual void handleHalt(canopen::LayerStatus &status) { /* TODO */ }
-    virtual void handleRecover(canopen::LayerStatus &status) { handleRead(status, Layer::Ready); }
+    virtual void handleRecover(canopen::LayerStatus &status) { /* nothing to do */ }
 
 };
 


### PR DESCRIPTION
this prevents a race condition, it is not needed anyway.