### PR TITLE
[jade] fix: handle EMCY as error, not as warning

### DIFF
--- a/canopen_master/src/emcy.cpp
+++ b/canopen_master/src/emcy.cpp
@@ -121,7 +121,7 @@ void EMCYHandler::handleInit(LayerStatus &status){
         return;
     }else if(error_register & 1){
         LOG("ER: " << int(error_register));
-        status.warn("Node has emergency error");
+        status.error("Node has emergency error");
         return;
     }
 


### PR DESCRIPTION
same as #228 