### PR TITLE
Feature: Reset errors before recover

### DIFF
--- a/canopen_chain_node/include/canopen_chain_node/ros_chain.h
+++ b/canopen_chain_node/include/canopen_chain_node/ros_chain.h
@@ -196,6 +196,8 @@ protected:
     boost::atomic<bool> running_;
     boost::mutex diag_mutex_;
 
+    bool reset_errors_before_recover_;
+
     void logState(const can::State &s);
     void run();
     virtual bool handle_init(std_srvs::Trigger::Request  &req, std_srvs::Trigger::Response &res);

--- a/canopen_master/src/emcy.cpp
+++ b/canopen_master/src/emcy.cpp
@@ -125,9 +125,13 @@ void EMCYHandler::handleInit(LayerStatus &status){
         return;
     }
 
+    resetErrors(status);
+}
+void EMCYHandler::resetErrors(LayerStatus &status){
     if(num_errors_.valid()) num_errors_.set(0);
     has_error_ = false;
 }
+
 void EMCYHandler::handleRecover(LayerStatus &status){
     handleInit(status);
 }


### PR DESCRIPTION
The feature introduces a flag to clear errors before recovering.
It might be needed for old Elmo controllersm but is turned off by default.

To turn it off `reset_errors_before_recover` should be set to "true" in private namespace.

@ipa-jba: Please test with new option
@ipa-nhg: Please test that recover works without setting this option on recent hardware