### PR TITLE
can id pass filter for socketcan bridge

### DIFF
--- a/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
+++ b/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
@@ -37,12 +37,15 @@ namespace socketcan_bridge
 class SocketCANToTopic
 {
   public:
-    SocketCANToTopic(ros::NodeHandle* nh, ros::NodeHandle* nh_param, boost::shared_ptr<can::DriverInterface> driver);
+    SocketCANToTopic(ros::NodeHandle* nh, ros::NodeHandle* nh_param,
+                     boost::shared_ptr<can::DriverInterface> driver,
+                     const std::vector<unsigned int>& pass_ids);
     void setup();
 
   private:
     ros::Publisher can_topic_;
     boost::shared_ptr<can::DriverInterface> driver_;
+    const std::vector<unsigned int> pass_ids_;
 
     can::CommInterface::FrameListener::Ptr frame_listener_;
     can::StateInterface::StateListener::Ptr state_listener_;
@@ -60,7 +63,7 @@ void convertSocketCANToMessage(const can::Frame& f, can_msgs::Frame& m)
   m.is_rtr = f.is_rtr;
   m.is_extended = f.is_extended;
 
-  for (int i = 0; i < 8; i++)  // always copy all data, regardless of dlc.
+  for (size_t i = 0; i < 8; i++)  // always copy all data, regardless of dlc.
   {
     m.data[i] = f.data[i];
   }

--- a/socketcan_bridge/src/socketcan_to_topic_node.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic_node.cpp
@@ -30,7 +30,7 @@
 #include <socketcan_interface/threading.h>
 #include <socketcan_interface/string.h>
 #include <string>
-
+#include <cstdlib>
 
 
 int main(int argc, char *argv[])
@@ -41,6 +41,26 @@ int main(int argc, char *argv[])
 
   std::string can_device;
   nh_param.param<std::string>("can_device", can_device, "can0");
+
+  std::vector<unsigned int> pass_can_ids;
+  if( nh_param.hasParam("can_ids") )
+  {
+    std::vector<std::string> ids;
+    nh_param.getParam("can_ids", ids);
+
+    for (size_t i=0; i < ids.size(); ++i)
+    {
+      unsigned int id = static_cast<unsigned int>(strtoul(ids[i].c_str(), NULL, 16));
+      if (id != 0)
+      {
+        pass_can_ids.push_back(id);
+      }
+      else
+      {
+        ROS_ERROR("Failed to parse can_id: %s from Param Server.", ids[i].c_str());
+      }
+    }
+  }
 
   boost::shared_ptr<can::ThreadedSocketCANInterface> driver = boost::make_shared<can::ThreadedSocketCANInterface> ();
 
@@ -54,7 +74,7 @@ int main(int argc, char *argv[])
     ROS_INFO("Successfully connected to %s.", can_device.c_str());
   }
 
-  socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver);
+  socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver, pass_can_ids);
   to_topic_bridge.setup();
 
   ros::spin();


### PR DESCRIPTION
Added feature to define a list of can ids which should be forwarded from can bus to ros. All other can ids are ignored. If the list is empty all messages get forwarded to ros.
```
Param: can_ids
Type: list<string>
Examples: 
- ['0x123', '0x321', '0x444']
- ['123', '321, '444']
```
solves https://github.com/ros-industrial/ros_canopen/issues/230
