### PR TITLE
Frame filters

### DIFF
--- a/socketcan_bridge/CMakeLists.txt
+++ b/socketcan_bridge/CMakeLists.txt
@@ -128,6 +128,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(test_to_topic
     socketcan_to_topic
+    topic_to_socketcan
     ${catkin_LIBRARIES}
   )
 

--- a/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
+++ b/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
@@ -29,6 +29,7 @@
 #define SOCKETCAN_BRIDGE_SOCKETCAN_TO_TOPIC_H
 
 #include <socketcan_interface/socketcan.h>
+#include <socketcan_interface/filter.h>
 #include <can_msgs/Frame.h>
 #include <ros/ros.h>
 
@@ -39,6 +40,9 @@ class SocketCANToTopic
   public:
     SocketCANToTopic(ros::NodeHandle* nh, ros::NodeHandle* nh_param, boost::shared_ptr<can::DriverInterface> driver);
     void setup();
+    void setup(const can::FilteredFrameListener::FilterVector &filters);
+    void setup(XmlRpc::XmlRpcValue filters);
+    void setup(ros::NodeHandle nh);
 
   private:
     ros::Publisher can_topic_;

--- a/socketcan_bridge/src/socketcan_bridge_node.cpp
+++ b/socketcan_bridge/src/socketcan_bridge_node.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
   to_socketcan_bridge.setup();
 
   socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver);
-  to_topic_bridge.setup();
+  to_topic_bridge.setup(nh_param);
 
   ros::spin();
 

--- a/socketcan_bridge/src/socketcan_to_topic.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic.cpp
@@ -84,8 +84,7 @@ namespace socketcan_bridge
   void SocketCANToTopic::frameCallback(const can::Frame& f)
     {
       // ROS_DEBUG("Message came in: %s", can::tostring(f, true).c_str());
-      can::Frame frame = f;  // copy the frame first, cannot call isValid() on const.
-      if (!frame.isValid())
+      if (!f.isValid())
       {
         ROS_ERROR("Invalid frame from SocketCAN: id: %#04x, length: %d, is_extended: %d, is_error: %d, is_rtr: %d",
                   f.id, f.dlc, f.is_extended, f.is_error, f.is_rtr);
@@ -103,7 +102,7 @@ namespace socketcan_bridge
 
       can_msgs::Frame msg;
       // converts the can::Frame (socketcan.h) to can_msgs::Frame (ROS msg)
-      convertSocketCANToMessage(frame, msg);
+      convertSocketCANToMessage(f, msg);
 
       msg.header.frame_id = "";  // empty frame is the de-facto standard for no frame.
       msg.header.stamp = ros::Time::now();

--- a/socketcan_bridge/src/socketcan_to_topic_node.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic_node.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
   }
 
   socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver);
-  to_topic_bridge.setup();
+  to_topic_bridge.setup(nh_param);
 
   ros::spin();
 

--- a/socketcan_bridge/test/to_topic_test.cpp
+++ b/socketcan_bridge/test/to_topic_test.cpp
@@ -93,6 +93,8 @@ TEST(SocketCANToTopicTest, checkCorrectData)
   ros::WallDuration(1.0).sleep();
   ros::spinOnce();
 
+  ASSERT_EQ(1, message_collector_.messages.size());
+
   // compare the received can_msgs::Frame message to the sent can::Frame.
   can_msgs::Frame received;
   received = message_collector_.messages.back();
@@ -193,6 +195,8 @@ TEST(SocketCANToTopicTest, checkCorrectCanIdFilter)
   ros::WallDuration(1.0).sleep();
   ros::spinOnce();
 
+  ASSERT_EQ(1, message_collector_.messages.size());
+
   // compare the received can_msgs::Frame message to the sent can::Frame.
   can_msgs::Frame received;
   received = message_collector_.messages.back();
@@ -247,9 +251,6 @@ TEST(SocketCANToTopicTest, checkInvalidCanIdFilter)
   ros::WallDuration(1.0).sleep();
   ros::spinOnce();
 
-  // compare the received can_msgs::Frame message to the sent can::Frame.
-  can_msgs::Frame received;
-  received = message_collector_.messages.back();
   EXPECT_EQ(0, message_collector_.messages.size());
 }
 

--- a/socketcan_bridge/test/to_topic_test.cpp
+++ b/socketcan_bridge/test/to_topic_test.cpp
@@ -144,6 +144,109 @@ TEST(SocketCANToTopicTest, checkInvalidFrameHandling)
   EXPECT_EQ(message_collector_.messages.size(), 1);
 }
 
+TEST(SocketCANToTopicTest, checkCorrectCanIdFilter)
+{
+  ros::NodeHandle nh(""), nh_param("~");
+
+  // create the dummy interface
+  boost::shared_ptr<can::DummyInterface> driver_ = boost::make_shared<can::DummyInterface>(true);
+
+  //create can_id vector with id that should be passed and published to ros
+  std::vector<unsigned int> pass_can_ids;
+  pass_can_ids.push_back(0x1337);
+
+  // start the to topic bridge.
+  socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver_);
+  to_topic_bridge.setup(can::tofilters(pass_can_ids));  // initiate the message callbacks
+
+  // init the driver to test stateListener (not checked automatically).
+  driver_->init("string_not_used", true);
+
+  // create a frame collector.
+  msgCollector message_collector_;
+
+  // register for messages on received_messages.
+  ros::Subscriber subscriber_ = nh.subscribe("received_messages", 1, &msgCollector::msgCallback, &message_collector_);
+
+  // create a can frame
+  can::Frame f;
+  f.is_extended = true;
+  f.is_rtr = false;
+  f.is_error = false;
+  f.id = 0x1337;
+  f.dlc = 8;
+  for (uint8_t i=0; i < f.dlc; i++)
+  {
+    f.data[i] = i;
+  }
+
+  // send the can frame to the driver
+  driver_->send(f);
+
+  // give some time for the interface some time to process the message
+  ros::WallDuration(1.0).sleep();
+  ros::spinOnce();
+
+  // compare the received can_msgs::Frame message to the sent can::Frame.
+  can_msgs::Frame received;
+  received = message_collector_.messages.back();
+  EXPECT_EQ(received.id, f.id);
+  EXPECT_EQ(received.dlc, f.dlc);
+  EXPECT_EQ(received.is_extended, f.is_extended);
+  EXPECT_EQ(received.is_rtr, f.is_rtr);
+  EXPECT_EQ(received.is_error, f.is_error);
+  EXPECT_EQ(received.data, f.data);
+}
+
+TEST(SocketCANToTopicTest, checkInvalidCanIdFilter)
+{
+  ros::NodeHandle nh(""), nh_param("~");
+
+  // create the dummy interface
+  boost::shared_ptr<can::DummyInterface> driver_ = boost::make_shared<can::DummyInterface>(true);
+
+  //create can_id vector with id that should not be received on can bus
+  std::vector<unsigned int> pass_can_ids;
+  pass_can_ids.push_back(0x300);
+
+  // start the to topic bridge.
+  socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver_);
+  to_topic_bridge.setup(can::tofilters(pass_can_ids));  // initiate the message callbacks
+
+  // init the driver to test stateListener (not checked automatically).
+  driver_->init("string_not_used", true);
+
+  // create a frame collector.
+  msgCollector message_collector_;
+
+  // register for messages on received_messages.
+  ros::Subscriber subscriber_ = nh.subscribe("received_messages", 1, &msgCollector::msgCallback, &message_collector_);
+
+  // create a can frame
+  can::Frame f;
+  f.is_extended = true;
+  f.is_rtr = false;
+  f.is_error = false;
+  f.id = 0x1337;
+  f.dlc = 8;
+  for (uint8_t i=0; i < f.dlc; i++)
+  {
+    f.data[i] = i;
+  }
+
+  // send the can frame to the driver
+  driver_->send(f);
+
+  // give some time for the interface some time to process the message
+  ros::WallDuration(1.0).sleep();
+  ros::spinOnce();
+
+  // compare the received can_msgs::Frame message to the sent can::Frame.
+  can_msgs::Frame received;
+  received = message_collector_.messages.back();
+  EXPECT_EQ(0, message_collector_.messages.size());
+}
+
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "test_to_topic");

--- a/socketcan_interface/CMakeLists.txt
+++ b/socketcan_interface/CMakeLists.txt
@@ -105,4 +105,12 @@ if(CATKIN_ENABLE_TESTING)
     socketcan_interface_string
     ${catkin_LIBRARIES}
   )
+
+  catkin_add_gtest(${PROJECT_NAME}-test_filter
+    test/test_filter.cpp
+  )
+  target_link_libraries(${PROJECT_NAME}-test_filter
+    socketcan_interface_string
+    ${catkin_LIBRARIES}
+  )
 endif()

--- a/socketcan_interface/CMakeLists.txt
+++ b/socketcan_interface/CMakeLists.txt
@@ -97,4 +97,12 @@ if(CATKIN_ENABLE_TESTING)
     socketcan_interface_string
     ${catkin_LIBRARIES}
   )
+
+  catkin_add_gtest(${PROJECT_NAME}-test_string
+    test/test_string.cpp
+  )
+  target_link_libraries(${PROJECT_NAME}-test_string
+    socketcan_interface_string
+    ${catkin_LIBRARIES}
+  )
 endif()

--- a/socketcan_interface/include/socketcan_interface/filter.h
+++ b/socketcan_interface/include/socketcan_interface/filter.h
@@ -1,0 +1,69 @@
+#ifndef SOCKETCAN_INTERFACE_FILTER_H
+#define SOCKETCAN_INTERFACE_FILTER_H
+
+#include <vector>
+
+#include "interface.h"
+
+namespace can {
+
+class FrameFilter {
+public:
+  typedef boost::shared_ptr<FrameFilter> Ptr;
+  virtual bool pass(const can::Frame &frame) const = 0;
+  virtual ~FrameFilter() {}
+};
+
+class FrameMaskFilter : public FrameFilter {
+public:
+  static const uint32_t MASK_ALL = 0xffffffff;
+  FrameMaskFilter(uint32_t can_id, uint32_t mask = MASK_ALL, bool invert = false)
+  : mask_(mask), masked_id_(can_id & mask), invert_(invert)
+  {}
+  virtual bool pass(const can::Frame &frame) const{
+    return ((mask_ & frame) == masked_id_) != invert_;
+  }
+private:
+  const uint32_t mask_;
+  const uint32_t masked_id_;
+  const bool invert_;
+};
+
+class FrameRangeFilter  : public FrameFilter {
+public:
+  FrameRangeFilter(uint32_t min_id, uint32_t max_id, bool invert = false)
+  : min_id_(min_id), max_id_(max_id), invert_(invert)
+  {}
+  virtual bool pass(const can::Frame &frame) const{
+    return (min_id_ <= frame && frame <= max_id_) != invert_;
+  }
+private:
+  const uint32_t min_id_;
+  const uint32_t max_id_;
+  const bool invert_;
+};
+
+class FilteredFrameListener : public CommInterface::FrameListener {
+public:
+  typedef std::vector<FrameFilter::Ptr> FilterVector;
+  FilteredFrameListener(boost::shared_ptr<CommInterface> comm, const Callable &callable, const FilterVector &filters)
+  : CommInterface::FrameListener(callable),
+    filters_(filters),
+    listener_(comm->createMsgListener(Callable(this, &FilteredFrameListener::filter)))
+  {}
+private:
+  void filter(const Frame &frame) {
+    for(FilterVector::const_iterator it=filters_.begin(); it != filters_.end(); ++it) {
+      if((*it)->pass(frame)){
+        (*this)(frame);
+        break;
+      }
+    }
+  }
+  const std::vector<FrameFilter::Ptr> filters_;
+  CommInterface::FrameListener::Ptr listener_;
+};
+
+} // namespace can
+
+#endif /*SOCKETCAN_INTERFACE_FILTER_H*/

--- a/socketcan_interface/include/socketcan_interface/filter.h
+++ b/socketcan_interface/include/socketcan_interface/filter.h
@@ -17,7 +17,8 @@ public:
 class FrameMaskFilter : public FrameFilter {
 public:
   static const uint32_t MASK_ALL = 0xffffffff;
-  FrameMaskFilter(uint32_t can_id, uint32_t mask = MASK_ALL, bool invert = false)
+  static const uint32_t MASK_RELAXED = ~Frame::EXTENDED_MASK;
+  FrameMaskFilter(uint32_t can_id, uint32_t mask = MASK_RELAXED, bool invert = false)
   : mask_(mask), masked_id_(can_id & mask), invert_(invert)
   {}
   virtual bool pass(const can::Frame &frame) const{

--- a/socketcan_interface/include/socketcan_interface/string.h
+++ b/socketcan_interface/include/socketcan_interface/string.h
@@ -30,6 +30,8 @@ template<class T> FrameFilter::Ptr tofilter(const T  &ct);
 template<> FrameFilter::Ptr tofilter(const std::string &s);
 template<> FrameFilter::Ptr tofilter(const uint32_t &id);
 
+FrameFilter::Ptr tofilter(const char* s);
+
 template <typename T> FilteredFrameListener::FilterVector tofilters(const T& v) {
     FilteredFrameListener::FilterVector filters;
     for(size_t i = 0; i < static_cast<size_t>(v.size()); ++i){

--- a/socketcan_interface/include/socketcan_interface/string.h
+++ b/socketcan_interface/include/socketcan_interface/string.h
@@ -2,9 +2,10 @@
 #define SOCKETCAN_INTERFACE_STRING_H
 
 #include "interface.h"
+#include "filter.h"
 #include <sstream>
 
-namespace can{
+namespace can {
 
 bool hex2dec(uint8_t& d, const char& h);
 
@@ -24,6 +25,18 @@ Header toheader(const std::string& s);
 std::string tostring(const Frame& f, bool lc);
 
 Frame toframe(const std::string& s);
+
+template<class T> FrameFilter::Ptr tofilter(const T  &ct);
+template<> FrameFilter::Ptr tofilter(const std::string &s);
+template<> FrameFilter::Ptr tofilter(const uint32_t &id);
+
+template <typename T> FilteredFrameListener::FilterVector tofilters(const T& v) {
+    FilteredFrameListener::FilterVector filters;
+    for(size_t i = 0; i < static_cast<size_t>(v.size()); ++i){
+        filters.push_back(tofilter(v[i]));
+    }
+    return filters;
+}
 
 }
 

--- a/socketcan_interface/src/string.cpp
+++ b/socketcan_interface/src/string.cpp
@@ -88,14 +88,16 @@ std::string tostring(const Header& h, bool lc) {
 	return buf.str();
 }
 
-Header toheader(const std::string& s) {
-	if (s.empty() || s.size() > 8)
-		return MsgHeader(0xfff); // invalid
+uint32_t tohex(const std::string& s) {
+		unsigned int h = 0;
+		std::stringstream stream;
+		stream << std::hex << s;
+		stream >> h;
+		return h;
+}
 
-	std::stringstream stream;
-	stream << std::hex << s;
-	unsigned int h = 0;
-	stream >> h;
+Header toheader(const std::string& s) {
+	unsigned int h = tohex(s);
 	return Header(h & Header::ID_MASK, h & Header::EXTENDED_MASK,
 			h & Header::RTR_MASK, h & Header::ERROR_MASK);
 }
@@ -139,7 +141,7 @@ template<> FrameFilter::Ptr tofilter(const std::string  &s){
 
 		if(delim != std::string::npos) {
 			type = s.at(delim);
-			second = toheader(s.substr(delim +1));
+			second = tohex(s.substr(delim +1));
 		}
 		uint32_t first = toheader(s.substr(0, delim));
 		switch (type) {
@@ -156,9 +158,12 @@ template<> FrameFilter::Ptr tofilter(const std::string  &s){
 		}
 		return FrameFilter::Ptr(filter);
 }
-
 template<> FrameFilter::Ptr tofilter(const uint32_t &id){
 		return FrameFilter::Ptr(new FrameMaskFilter(id));
+}
+
+FrameFilter::Ptr tofilter(const char* s){
+		return tofilter<std::string>(s);
 }
 
 }

--- a/socketcan_interface/src/string.cpp
+++ b/socketcan_interface/src/string.cpp
@@ -133,7 +133,7 @@ template<> FrameFilter::Ptr tofilter(const std::string  &s){
 	  FrameFilter * filter = 0;
 		size_t delim = s.find_first_of(":~-_");
 
-		uint32_t second = FrameMaskFilter::MASK_ALL;
+		uint32_t second = FrameMaskFilter::MASK_RELAXED;
 		bool invert = false;
 		char type = ':';
 

--- a/socketcan_interface/src/string.cpp
+++ b/socketcan_interface/src/string.cpp
@@ -129,6 +129,38 @@ Frame toframe(const std::string& s) {
 	return frame;
 }
 
+template<> FrameFilter::Ptr tofilter(const std::string  &s){
+	  FrameFilter * filter = 0;
+		size_t delim = s.find_first_of(":~-_");
+
+		uint32_t second = FrameMaskFilter::MASK_ALL;
+		bool invert = false;
+		char type = ':';
+
+		if(delim != std::string::npos) {
+			type = s.at(delim);
+			second = toheader(s.substr(delim +1));
+		}
+		uint32_t first = toheader(s.substr(0, delim));
+		switch (type) {
+			case '~':
+				invert = true;
+			case ':':
+				filter = new FrameMaskFilter(first, second, invert);
+				break;
+			case '_':
+				invert = true;
+			case '-':
+				filter = new FrameRangeFilter(first, second, invert);
+				break;
+		}
+		return FrameFilter::Ptr(filter);
+}
+
+template<> FrameFilter::Ptr tofilter(const uint32_t &id){
+		return FrameFilter::Ptr(new FrameMaskFilter(id));
+}
+
 }
 
 std::ostream& operator <<(std::ostream& stream, const can::Header& h) {

--- a/socketcan_interface/src/string.cpp
+++ b/socketcan_interface/src/string.cpp
@@ -89,7 +89,7 @@ std::string tostring(const Header& h, bool lc) {
 }
 
 Header toheader(const std::string& s) {
-	if (s.empty() || s.size() > 4)
+	if (s.empty() || s.size() > 8)
 		return MsgHeader(0xfff); // invalid
 
 	std::stringstream stream;

--- a/socketcan_interface/test/test_filter.cpp
+++ b/socketcan_interface/test/test_filter.cpp
@@ -3,6 +3,7 @@
 
 
 #include <socketcan_interface/string.h>
+#include <socketcan_interface/dummy.h>
 
 // Bring in gtest
 #include <gtest/gtest.h>
@@ -65,6 +66,39 @@ TEST(FilterTest, rangeTest)
   EXPECT_TRUE(f3->pass(can::toframe(msg1)));
   EXPECT_TRUE(f3->pass(can::toframe(msg2)));
   EXPECT_FALSE(f3->pass(can::toframe(msg3)));
+
+}
+
+class Counter {
+public:
+    size_t count_;
+    Counter(): count_(0) {}
+    void count(const can::Frame &frame) {
+      ++count_;
+    }
+};
+
+TEST(FilterTest, listenerTest)
+{
+
+  Counter counter;
+  boost::shared_ptr<can::CommInterface> dummy(new can::DummyInterface(true));
+
+  can::FilteredFrameListener::FilterVector filters;
+  filters.push_back(can::tofilter("123:FFE"));
+
+  can::CommInterface::FrameListener::Ptr  listener(new can::FilteredFrameListener(dummy,can::CommInterface::FrameDelegate(&counter, &Counter::count), filters));
+
+  can::Frame f1 = can::toframe("123#");
+  can::Frame f2 = can::toframe("124#");
+  can::Frame f3 = can::toframe("122#");
+
+  dummy->send(f1);
+  EXPECT_EQ(1, counter.count_);
+  dummy->send(f2);
+  EXPECT_EQ(1, counter.count_);
+  dummy->send(f3);
+  EXPECT_EQ(2, counter.count_);
 
 }
 

--- a/socketcan_interface/test/test_filter.cpp
+++ b/socketcan_interface/test/test_filter.cpp
@@ -1,0 +1,75 @@
+// Bring in my package's API, which is what I'm testing
+#include <socketcan_interface/filter.h>
+
+
+#include <socketcan_interface/string.h>
+
+// Bring in gtest
+#include <gtest/gtest.h>
+
+
+TEST(FilterTest, simpleMask)
+{
+  const std::string msg1("123#");
+  const std::string msg2("124#");
+
+  can::FrameFilter::Ptr f1 = can::tofilter("123");
+
+  EXPECT_TRUE(f1->pass(can::toframe(msg1)));
+  EXPECT_FALSE(f1->pass(can::toframe(msg2)));
+}
+
+TEST(FilterTest, maskTests)
+{
+  const std::string msg1("123#");
+  const std::string msg2("124#");
+  const std::string msg3("122#");
+
+  can::FrameFilter::Ptr f1 = can::tofilter("123:123");
+  can::FrameFilter::Ptr f2 = can::tofilter("123:ffe");
+  can::FrameFilter::Ptr f3 = can::tofilter("123~123");
+
+  EXPECT_TRUE(f1->pass(can::toframe(msg1)));
+  EXPECT_FALSE(f1->pass(can::toframe(msg2)));
+  EXPECT_FALSE(f1->pass(can::toframe(msg3)));
+
+
+  EXPECT_TRUE(f2->pass(can::toframe(msg1)));
+  EXPECT_FALSE(f2->pass(can::toframe(msg2)));
+  EXPECT_TRUE(f2->pass(can::toframe(msg3)));
+
+  EXPECT_FALSE(f3->pass(can::toframe(msg1)));
+  EXPECT_TRUE(f3->pass(can::toframe(msg2)));
+  EXPECT_TRUE(f3->pass(can::toframe(msg3)));
+
+}
+
+TEST(FilterTest, rangeTest)
+{
+  const std::string msg1("120#");
+  const std::string msg2("125#");
+  const std::string msg3("130#");
+
+  can::FrameFilter::Ptr f1 = can::tofilter("120-120");
+  can::FrameFilter::Ptr f2 = can::tofilter("120_120");
+  can::FrameFilter::Ptr f3 = can::tofilter("120-125");
+
+  EXPECT_TRUE(f1->pass(can::toframe(msg1)));
+  EXPECT_FALSE(f1->pass(can::toframe(msg2)));
+  EXPECT_FALSE(f1->pass(can::toframe(msg3)));
+
+  EXPECT_FALSE(f2->pass(can::toframe(msg1)));
+  EXPECT_TRUE(f2->pass(can::toframe(msg2)));
+  EXPECT_TRUE(f2->pass(can::toframe(msg3)));
+
+  EXPECT_TRUE(f3->pass(can::toframe(msg1)));
+  EXPECT_TRUE(f3->pass(can::toframe(msg2)));
+  EXPECT_FALSE(f3->pass(can::toframe(msg3)));
+
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv){
+testing::InitGoogleTest(&argc, argv);
+return RUN_ALL_TESTS();
+}

--- a/socketcan_interface/test/test_string.cpp
+++ b/socketcan_interface/test/test_string.cpp
@@ -1,0 +1,27 @@
+// Bring in my package's API, which is what I'm testing
+#include <socketcan_interface/string.h>
+
+// Bring in gtest
+#include <gtest/gtest.h>
+
+
+TEST(StringTest, stringconversion)
+{
+  const std::string s1("123#1234567812345678");
+  can::Frame f1 = can::toframe(s1);
+  EXPECT_EQ(s1, can::tostring(f1, true));
+
+  const std::string s2("1337#1234567812345678");
+  can::Frame f2 = can::toframe(s2);
+  EXPECT_FALSE(f2.isValid());
+
+  const std::string s3("80001337#1234567812345678");
+  can::Frame f3 = can::toframe(s3);
+  EXPECT_EQ(s3, can::tostring(f3, true));
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv){
+testing::InitGoogleTest(&argc, argv);
+return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
supersedes #245, closes #230 

This is an extended version of #245 with masks and ranges.

The syntax for the `can_ids` param is a little bit different and support candump-like filters.

A simple filter list can be applied with (by default it works for standard and extended IDs):
```yaml
- [0x123, 0x321, 0x444] # hex in yaml
- ['123', '321, '444'] # strings are hex
- [291, 801, 1092] # decimal!
```
For strings masks and ranges can be added:
* `CAN_ID:MASK` -> FRAME_ID & MASK ==  CAN_ID & MASK
* `CAN_ID~MASK` -> FRAME_ID & MASK !=  CAN_ID & MASK
* `MIN_ID-MAX_ID` -> FRAME_ID in range [MIN_ID, MAX_ID]
* `MIN_ID_MAX_ID` -> FRAME_ID not in range [MIN_ID, MAX_ID]
Examples:
```yaml
- ['123'] # default mask 0x7FFFFFFF matches 0x123 (standard) and 0x80000123 (extended)
- ['123#FFFFFFFF'] # matches 0x123 (standard)
- ['80000123#FFFFFFFF'] # 0x80000123 (extended)
- ['123-125'] # matches 0x123, 0x124 and 0x125
```



