### PR TITLE
explicitly include iostream to compile with boost >= 1.65.0

### DIFF
--- a/socketcan_interface/include/socketcan_interface/interface.h
+++ b/socketcan_interface/include/socketcan_interface/interface.h
@@ -190,6 +190,7 @@ public:
 
 } // namespace can
 
+#include <iostream>
 #include <boost/thread/mutex.hpp>
 
 struct _cout_wrapper{


### PR DESCRIPTION
When compiling with boost version >= 1.65.0, it fails with:
```
In file included from /[...]/include/socketcan_interface/asio_base.h:4:0,
                 from /[...]/include/socketcan_interface/socketcan.h:4,
                 from /[...]/src/socketcan_interface_plugin.cpp:2:
/[...]/include/socketcan_interface/socketcan.h: In member function 'virtual bool can::SocketCANInterface::enqueue(const can::Frame&)':
/[...]/include/socketcan_interface/interface.h:202:96: error: 'cout' is not a member of 'std'
 #define LOG(log) { boost::mutex::scoped_lock _cout_lock(_cout_wrapper::get_cout_mutex()); std::cout << log << std::endl; }
                                                                                                ^
/[...]/include/socketcan_interface/socketcan.h:183:13: note: in expansion of macro 'LOG'
             LOG("FAILED " << ec);
             ^
/[...]/include/socketcan_interface/interface.h:202:96: note: suggested alternative: 'count'
```

With boost version < 1.65.0, iostream is probably included by the boost dependencies in the header files; with boost version >= 1.65.0, it is not included anymore and hence leads to this compile error.

The issue was identified by the work on meta-ros, the OpenEmbedded layer for ROS [1,2]. It provides a cross-compilation tool chain for ROS packages and its current master version already uses boost version 1.65.1.

[1] https://github.com/bmwcarit/meta-ros
[2] https://github.com/bulwahn/meta-ros/pull/8

Ideally, this patch is also backported to the indigo-devel branch.