### PR TITLE
Removing CAN_ERR_LOSTARB from the list of errors. Reasoning is, that …

### DIFF
--- a/socketcan_interface/include/socketcan_interface/socketcan.h
+++ b/socketcan_interface/include/socketcan_interface/socketcan.h
@@ -53,7 +53,7 @@ public:
             }
             can_err_mask_t err_mask =
                 ( CAN_ERR_TX_TIMEOUT   /* TX timeout (by netdevice driver) */
-                | CAN_ERR_LOSTARB      /* lost arbitration    / data[0]    */
+		//| CAN_ERR_LOSTARB      /* lost arbitration    / data[0]    */
                 | CAN_ERR_CRTL         /* controller problems / data[1]    */
                 | CAN_ERR_PROT         /* protocol violations / data[2..3] */
                 | CAN_ERR_TRX          /* transceiver status  / data[4]    */


### PR DESCRIPTION
…for example sja1000 based cards issue this error frame, even though, the message is send over the can bus, as lost Arbitrations are a rather common thing to happen on a CAN bus. Since this is rather a statistical hint, not an error per se, it is the wrong behavior to put the socketcan_interface into error state, which can only be resolved by "recover()", i.e. close and open the driver again.

I can confirm this behavior for an sja1000 based card. There are (only) 3 more drivers, that use this error frame at all (rcar, sun4i, xilinx). Have not tested those.