### PR TITLE
compile also with boost >= 1.66.0

### DIFF
--- a/socketcan_interface/include/socketcan_interface/asio_base.h
+++ b/socketcan_interface/include/socketcan_interface/asio_base.h
@@ -23,7 +23,11 @@ template<typename Socket> class AsioDriver : public DriverInterface{
     
 protected:
     boost::asio::io_service io_service_;
+#if BOOST_ASIO_VERSION >= 101200 // Boost 1.66+
+    boost::asio::io_context::strand strand_;
+#else
     boost::asio::strand strand_;
+#endif
     Socket socket_;
     Frame input_;
     


### PR DESCRIPTION
In boost 1.66.0, which includes boost-asio 1.12.0, the asio interfaces have been changed to follow the "C++ Extensions for Networking" Technical Specification [1]. As a consequence, the type `boost::asio::strand` has been moved to `boost::asio::io_service::strand`.

A preprocessing directive ensures backwards compatibility using the provided boost-asio version [2].

[1] http://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/net_ts.html
[2] boostorg/asio@0c9cbdf