### PR TITLE
Preparation for C++14 migration

### DIFF
--- a/canopen_402/include/canopen_402/base.h
+++ b/canopen_402/include/canopen_402/base.h
@@ -28,14 +28,17 @@ public:
     virtual bool enterModeAndWait(uint16_t mode) = 0;
     virtual bool isModeSupported(uint16_t mode) = 0;
     virtual uint16_t getMode() = 0;
-    virtual void registerDefaultModes(boost::shared_ptr<ObjectStorage> storage) {}
+    virtual void registerDefaultModes(ObjectStorageSharedPtr storage) {}
+
+    typedef boost::shared_ptr<MotorBase> MotorBaseSharedPtr;
 
     class Allocator {
     public:
-        virtual boost::shared_ptr<MotorBase> allocate(const std::string &name, boost::shared_ptr<ObjectStorage> storage, const canopen::Settings &settings) = 0;
+        virtual MotorBaseSharedPtr allocate(const std::string &name, ObjectStorageSharedPtr storage, const canopen::Settings &settings) = 0;
         virtual ~Allocator() {}
     };
 };
+typedef MotorBase::MotorBaseSharedPtr MotorBaseSharedPtr;
 
 }
 

--- a/canopen_402/include/canopen_402/motor.h
+++ b/canopen_402/include/canopen_402/motor.h
@@ -379,7 +379,8 @@ private:
 
     boost::mutex map_mutex_;
     boost::unordered_map<uint16_t, ModeSharedPtr > modes_;
-    boost::unordered_map<uint16_t, boost::function<void()> > mode_allocators_;
+    typedef boost::function<void()> AllocFuncType;
+    boost::unordered_map<uint16_t, AllocFuncType> mode_allocators_;
 
     ModeSharedPtr selected_mode_;
     uint16_t mode_id_;

--- a/canopen_402/include/canopen_402/motor.h
+++ b/canopen_402/include/canopen_402/motor.h
@@ -137,7 +137,7 @@ public:
     virtual bool setTarget(const double &val) { LOG("not implemented"); return false; }
     virtual ~Mode() {}
 };
-
+typedef boost::shared_ptr<Mode> ModeSharedPtr;
 
 template<typename T> class ModeTargetHelper : public Mode {
     T target_;
@@ -183,7 +183,7 @@ public:
 template<uint16_t ID, typename TYPE, uint16_t OBJ, uint8_t SUB, uint16_t CW_MASK> class ModeForwardHelper : public ModeTargetHelper<TYPE> {
     canopen::ObjectStorage::Entry<TYPE> target_entry_;
 public:
-    ModeForwardHelper(boost::shared_ptr<ObjectStorage> storage) : ModeTargetHelper<TYPE>(ID) {
+    ModeForwardHelper(ObjectStorageSharedPtr storage) : ModeTargetHelper<TYPE>(ID) {
         if(SUB) storage->entry(target_entry_, OBJ, SUB);
         else storage->entry(target_entry_, OBJ);
     }
@@ -223,7 +223,7 @@ public:
         CW_Immediate =  Command402::CW_Operation_mode_specific1,
         CW_Blending =  Command402::CW_Operation_mode_specific3,
     };
-    ProfiledPositionMode(boost::shared_ptr<ObjectStorage> storage) : ModeTargetHelper(MotorBase::Profiled_Position) {
+    ProfiledPositionMode(ObjectStorageSharedPtr storage) : ModeTargetHelper(MotorBase::Profiled_Position) {
         storage->entry(target_position_, 0x607A);
     }
     virtual bool start() { sw_ = 0; last_target_= std::numeric_limits<double>::quiet_NaN(); return ModeTargetHelper::start(); }
@@ -278,7 +278,7 @@ class DefaultHomingMode: public HomingMode{
     };
     bool error(canopen::LayerStatus &status, const std::string& msg) { execute_= false; status.error(msg); return false; }
 public:
-    DefaultHomingMode(boost::shared_ptr<ObjectStorage> storage) {
+    DefaultHomingMode(ObjectStorageSharedPtr storage) {
         storage->entry(homing_method_, 0x6098);
     }
     virtual bool start();
@@ -292,7 +292,7 @@ class Motor402 : public MotorBase
 {
 public:
 
-    Motor402(const std::string &name, boost::shared_ptr<ObjectStorage> storage, const canopen::Settings &settings)
+    Motor402(const std::string &name, ObjectStorageSharedPtr storage, const canopen::Settings &settings)
     : MotorBase(name), status_word_(0),control_word_(0),
       switching_state_(State402::InternalState(settings.get_optional<unsigned int>("switching_state", static_cast<unsigned int>(State402::Operation_Enable)))),
       monitor_mode_(settings.get_optional<bool>("monitor_mode", true))
@@ -323,7 +323,7 @@ public:
         return mode_allocators_.insert(std::make_pair(mode, boost::bind(&Motor402::createAndRegister<T,T1,T2>, this, mode, t1, t2))).second;
     }
 
-    virtual void registerDefaultModes(boost::shared_ptr<ObjectStorage> storage){
+    virtual void registerDefaultModes(ObjectStorageSharedPtr storage){
         registerMode<ProfiledPositionMode> (MotorBase::Profiled_Position, storage);
         registerMode<VelocityMode> (MotorBase::Velocity, storage);
         registerMode<ProfiledVelocityMode> (MotorBase::Profiled_Velocity, storage);
@@ -337,7 +337,7 @@ public:
 
     class Allocator : public MotorBase::Allocator{
     public:
-        virtual boost::shared_ptr<MotorBase> allocate(const std::string &name, boost::shared_ptr<ObjectStorage> storage, const canopen::Settings &settings);
+        virtual MotorBaseSharedPtr allocate(const std::string &name, ObjectStorageSharedPtr storage, const canopen::Settings &settings);
     };
 protected:
     virtual void handleRead(LayerStatus &status, const LayerState &current_state);
@@ -350,19 +350,19 @@ protected:
 
 private:
     template<typename T> void createAndRegister0(uint16_t mode){
-        if(isModeSupportedByDevice(mode)) registerMode(mode, boost::shared_ptr<Mode>(new T()));
+        if(isModeSupportedByDevice(mode)) registerMode(mode, ModeSharedPtr(new T()));
     }
     template<typename T, typename T1> void createAndRegister(uint16_t mode, const T1& t1){
-        if(isModeSupportedByDevice(mode)) registerMode(mode, boost::shared_ptr<Mode>(new T(t1)));
+        if(isModeSupportedByDevice(mode)) registerMode(mode, ModeSharedPtr(new T(t1)));
     }
     template<typename T, typename T1, typename T2> void createAndRegister(uint16_t mode, const T1& t1, const T2& t2){
-        if(isModeSupportedByDevice(mode)) registerMode(mode, boost::shared_ptr<Mode>(new T(t1,t2)));
+        if(isModeSupportedByDevice(mode)) registerMode(mode, ModeSharedPtr(new T(t1,t2)));
     }
 
     virtual bool isModeSupportedByDevice(uint16_t mode);
-    void registerMode(uint16_t id, const boost::shared_ptr<Mode> &m);
+    void registerMode(uint16_t id, const ModeSharedPtr &m);
 
-    boost::shared_ptr<Mode> allocMode(uint16_t mode);
+    ModeSharedPtr allocMode(uint16_t mode);
 
     bool readState(LayerStatus &status, const LayerState &current_state);
     bool switchMode(LayerStatus &status, uint16_t mode);
@@ -378,10 +378,10 @@ private:
     State402 state_handler_;
 
     boost::mutex map_mutex_;
-    boost::unordered_map<uint16_t, boost::shared_ptr<Mode> > modes_;
+    boost::unordered_map<uint16_t, ModeSharedPtr > modes_;
     boost::unordered_map<uint16_t, boost::function<void()> > mode_allocators_;
 
-    boost::shared_ptr<Mode> selected_mode_;
+    ModeSharedPtr selected_mode_;
     uint16_t mode_id_;
     boost::condition_variable mode_cond_;
     boost::mutex mode_mutex_;

--- a/canopen_402/src/motor.cpp
+++ b/canopen_402/src/motor.cpp
@@ -465,7 +465,7 @@ void Motor402::handleDiag(LayerReport &report){
     }
 }
 void Motor402::handleInit(LayerStatus &status){
-    for(boost::unordered_map<uint16_t, boost::function<void()> >::iterator it = mode_allocators_.begin(); it != mode_allocators_.end(); ++it){
+    for(boost::unordered_map<uint16_t, AllocFuncType>::iterator it = mode_allocators_.begin(); it != mode_allocators_.end(); ++it){
         (it->second)();
     }
 

--- a/canopen_402/src/motor.cpp
+++ b/canopen_402/src/motor.cpp
@@ -267,16 +267,16 @@ uint16_t Motor402::getMode() {
 bool Motor402::isModeSupportedByDevice(uint16_t mode){
     return mode > 0 && supported_drive_modes_.valid() && (supported_drive_modes_.get_cached() & (1<<(mode-1)));
 }
-void Motor402::registerMode(uint16_t id, const boost::shared_ptr<Mode> &m){
+void Motor402::registerMode(uint16_t id, const ModeSharedPtr &m){
     boost::mutex::scoped_lock map_lock(map_mutex_);
     if(m && m->mode_id_ == id) modes_.insert(std::make_pair(id, m));
 }
 
-boost::shared_ptr<Mode> Motor402::allocMode(uint16_t mode){
-    boost::shared_ptr<Mode> res;
+ModeSharedPtr Motor402::allocMode(uint16_t mode){
+    ModeSharedPtr res;
     if(isModeSupportedByDevice(mode)){
         boost::mutex::scoped_lock map_lock(map_mutex_);
-        boost::unordered_map<uint16_t, boost::shared_ptr<Mode> >::iterator it = modes_.find(mode);
+        boost::unordered_map<uint16_t, ModeSharedPtr >::iterator it = modes_.find(mode);
         if(it != modes_.end()){
             res = it->second;
         }
@@ -295,7 +295,7 @@ bool Motor402::switchMode(LayerStatus &status, uint16_t mode) {
         return true;
     }
 
-    boost::shared_ptr<Mode> next_mode = allocMode(mode);
+    ModeSharedPtr next_mode = allocMode(mode);
     if(!next_mode){
         status.error("Mode is not supported.");
         return false;
@@ -483,7 +483,7 @@ void Motor402::handleInit(LayerStatus &status){
         return;
     }
 
-    boost::shared_ptr<Mode> m = allocMode(MotorBase::Homing);
+    ModeSharedPtr m = allocMode(MotorBase::Homing);
     if(!m){
         return; // homing not supported
     }

--- a/canopen_402/src/plugin.cpp
+++ b/canopen_402/src/plugin.cpp
@@ -1,7 +1,7 @@
 #include <class_loader/class_loader.h>
 #include <canopen_402/motor.h>
 
-boost::shared_ptr<canopen::MotorBase> canopen::Motor402::Allocator::allocate(const std::string &name, boost::shared_ptr<canopen::ObjectStorage> storage, const canopen::Settings &settings) {
+canopen::MotorBaseSharedPtr canopen::Motor402::Allocator::allocate(const std::string &name, canopen::ObjectStorageSharedPtr storage, const canopen::Settings &settings) {
     return boost::make_shared<canopen::Motor402>(name, storage, settings);
 }
 

--- a/canopen_402/src/plugin.cpp
+++ b/canopen_402/src/plugin.cpp
@@ -2,7 +2,7 @@
 #include <canopen_402/motor.h>
 
 canopen::MotorBaseSharedPtr canopen::Motor402::Allocator::allocate(const std::string &name, canopen::ObjectStorageSharedPtr storage, const canopen::Settings &settings) {
-    return boost::make_shared<canopen::Motor402>(name, storage, settings);
+    return make_shared<canopen::Motor402>(name, storage, settings);
 }
 
 CLASS_LOADER_REGISTER_CLASS(canopen::Motor402::Allocator, canopen::MotorBase::Allocator);

--- a/canopen_chain_node/include/canopen_chain_node/ros_chain.h
+++ b/canopen_chain_node/include/canopen_chain_node/ros_chain.h
@@ -20,7 +20,7 @@ class PublishFunc{
 public:
     typedef boost::function<void()> func_type;
 
-    static func_type create(ros::NodeHandle &nh,  const std::string &name, boost::shared_ptr<canopen::Node> node, const std::string &key, bool force);
+    static func_type create(ros::NodeHandle &nh,  const std::string &name, canopen::NodeSharedPtr node, const std::string &key, bool force);
 private:
     template <typename Tpub, typename Tobj, bool forced> static void publish(ros::Publisher &pub, ObjectStorage::Entry<Tobj> &entry){
 		Tpub msg;
@@ -58,7 +58,7 @@ public:
 };
 
 class Logger: public DiagGroup<canopen::Layer>{
-    const boost::shared_ptr<canopen::Node> node_;
+    const canopen::NodeSharedPtr node_;
 
     std::vector<boost::function< void (diagnostic_updater::DiagnosticStatusWrapper &)> > entries_;
 
@@ -73,12 +73,12 @@ class Logger: public DiagGroup<canopen::Layer>{
     }
 
 public:
-    Logger(boost::shared_ptr<canopen::Node> node):  node_(node) { add(node_); }
+    Logger(canopen::NodeSharedPtr node):  node_(node) { add(node_); }
 
     bool add(uint8_t level, const std::string &key, bool forced){
         try{
             ObjectDict::Key k(key);
-            const boost::shared_ptr<const ObjectDict::Entry> entry = node_->getStorage()->dict_->get(k);
+            const ObjectDict::EntryConstSharedPtr entry = node_->getStorage()->dict_->get(k);
             std::string name = entry->desc.empty() ? key : entry->desc;
             entries_.push_back(boost::bind(log_entry, _1, level, name, node_->getStorage()->getStringReader(k, !forced)));
             return true;
@@ -110,18 +110,21 @@ public:
     }
     virtual ~Logger() {}
 };
+typedef boost::shared_ptr<Logger> LoggerSharedPtr;
 
 class GuardedClassLoaderList {
-    static std::vector< boost::shared_ptr<pluginlib::ClassLoaderBase> >& guarded_loaders(){
-        static std::vector< boost::shared_ptr<pluginlib::ClassLoaderBase> > loaders;
-        return loaders;
-    }
 public:
-    static void addLoader(boost::shared_ptr<pluginlib::ClassLoaderBase> b){
+    typedef boost::shared_ptr<pluginlib::ClassLoaderBase> ClassLoaderBaseSharedPtr;
+    static void addLoader(ClassLoaderBaseSharedPtr b){
         guarded_loaders().push_back(b);
     }
    ~GuardedClassLoaderList(){
        guarded_loaders().clear();
+   }
+private:
+   static std::vector< ClassLoaderBaseSharedPtr>& guarded_loaders(){
+       static std::vector<ClassLoaderBaseSharedPtr> loaders;
+       return loaders;
    }
 };
 
@@ -129,25 +132,27 @@ template<typename T> class GuardedClassLoader {
     typedef pluginlib::ClassLoader<T> Loader;
     boost::shared_ptr<Loader> loader_;
 public:
+    typedef boost::shared_ptr<T> ClassSharedPtr;
     GuardedClassLoader(const std::string& package, const std::string& allocator_base_class)
     : loader_(new Loader(package, allocator_base_class)) {
         GuardedClassLoaderList::addLoader(loader_);
     }
-    boost::shared_ptr<T> createInstance(const std::string& lookup_name){
+    ClassSharedPtr createInstance(const std::string& lookup_name){
         return loader_->createInstance(lookup_name);
     }
 };
 
 template<typename T> class ClassAllocator : public GuardedClassLoader<typename T::Allocator> {
 public:
+    typedef boost::shared_ptr<T> ClassSharedPtr;
     ClassAllocator (const std::string& package, const std::string& allocator_base_class) : GuardedClassLoader<typename T::Allocator>(package, allocator_base_class) {}
-    template<typename T1> boost::shared_ptr<T> allocateInstance(const std::string& lookup_name, const T1 & t1){
+    template<typename T1> ClassSharedPtr allocateInstance(const std::string& lookup_name, const T1 & t1){
         return this->createInstance(lookup_name)->allocate(t1);
     }
-    template<typename T1, typename T2> boost::shared_ptr<T> allocateInstance(const std::string& lookup_name, const T1 & t1, const T2 & t2){
+    template<typename T1, typename T2> ClassSharedPtr allocateInstance(const std::string& lookup_name, const T1 & t1, const T2 & t2){
         return this->createInstance(lookup_name)->allocate(t1, t2);
     }
-    template<typename T1, typename T2, typename T3> boost::shared_ptr<T> allocateInstance(const std::string& lookup_name, const T1 & t1, const T2 & t2, const T3 & t3){
+    template<typename T1, typename T2, typename T3> ClassSharedPtr allocateInstance(const std::string& lookup_name, const T1 & t1, const T2 & t2, const T3 & t3){
         return this->createInstance(lookup_name)->allocate(t1, t2, t3);
     }
 };
@@ -155,16 +160,16 @@ class RosChain : GuardedClassLoaderList, public canopen::LayerStack {
     GuardedClassLoader<can::DriverInterface> driver_loader_;
     ClassAllocator<canopen::Master> master_allocator_;
 protected:
-    boost::shared_ptr<can::DriverInterface> interface_;
-    boost::shared_ptr<Master> master_;
+    can::DriverInterfaceSharedPtr interface_;
+    MasterSharedPtr master_;
     boost::shared_ptr<canopen::LayerGroupNoDiag<canopen::Node> > nodes_;
     boost::shared_ptr<canopen::LayerGroupNoDiag<canopen::EMCYHandler> > emcy_handlers_;
-    std::map<std::string, boost::shared_ptr<canopen::Node> > nodes_lookup_;
-    boost::shared_ptr<canopen::SyncLayer> sync_;
-    std::vector<boost::shared_ptr<Logger > > loggers_;
+    std::map<std::string, canopen::NodeSharedPtr > nodes_lookup_;
+    canopen::SyncLayerSharedPtr sync_;
+    std::vector<LoggerSharedPtr > loggers_;
     std::vector<PublishFunc::func_type> publishers_;
 
-    can::StateInterface::StateListener::Ptr state_listener_;
+    can::StateListenerConstSharedPtr state_listener_;
 
     boost::scoped_ptr<boost::thread> thread_;
 
@@ -186,7 +191,7 @@ protected:
 
     struct HeartbeatSender{
       can::Frame frame;
-      boost::shared_ptr<can::DriverInterface> interface;
+      can::DriverInterfaceSharedPtr interface;
       bool send(){
           return interface && interface->send(frame);
       }
@@ -214,7 +219,7 @@ protected:
     bool setup_sync();
     bool setup_heartbeat();
     bool setup_nodes();
-    virtual bool nodeAdded(XmlRpc::XmlRpcValue &params, const boost::shared_ptr<canopen::Node> &node, const boost::shared_ptr<Logger> &logger);
+    virtual bool nodeAdded(XmlRpc::XmlRpcValue &params, const canopen::NodeSharedPtr &node, const LoggerSharedPtr &logger);
     void report_diagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat);
     virtual bool setup_chain();
 public:
@@ -226,4 +231,3 @@ public:
 } //namespace canopen
 
 #endif
-

--- a/canopen_chain_node/include/canopen_chain_node/ros_chain.h
+++ b/canopen_chain_node/include/canopen_chain_node/ros_chain.h
@@ -18,16 +18,17 @@ namespace canopen{
 
 class PublishFunc{
 public:
-    typedef boost::function<void()> func_type;
+    typedef boost::function<void()> func_type ROS_DEPRECATED;
+    typedef boost::function<void()> FuncType;
 
-    static func_type create(ros::NodeHandle &nh,  const std::string &name, canopen::NodeSharedPtr node, const std::string &key, bool force);
+    static FuncType create(ros::NodeHandle &nh,  const std::string &name, canopen::NodeSharedPtr node, const std::string &key, bool force);
 private:
     template <typename Tpub, typename Tobj, bool forced> static void publish(ros::Publisher &pub, ObjectStorage::Entry<Tobj> &entry){
 		Tpub msg;
 		msg.data = (const typename Tpub::_data_type &)(forced? entry.get() : entry.get_cached());
         pub.publish(msg);
     }
-    template<typename Tpub, typename Tobj> static func_type create(ros::NodeHandle &nh,  const std::string &name, ObjectStorage::Entry<Tobj> entry, bool force){
+    template<typename Tpub, typename Tobj> static FuncType create(ros::NodeHandle &nh,  const std::string &name, ObjectStorage::Entry<Tobj> entry, bool force){
         if(!entry.valid()) return 0;
         ros::Publisher pub = nh.advertise<Tpub>(name, 1);
         if(force){
@@ -167,7 +168,7 @@ protected:
     std::map<std::string, canopen::NodeSharedPtr > nodes_lookup_;
     canopen::SyncLayerSharedPtr sync_;
     std::vector<LoggerSharedPtr > loggers_;
-    std::vector<PublishFunc::func_type> publishers_;
+    std::vector<PublishFunc::FuncType> publishers_;
 
     can::StateListenerConstSharedPtr state_listener_;
 

--- a/canopen_chain_node/src/ros_chain.cpp
+++ b/canopen_chain_node/src/ros_chain.cpp
@@ -16,7 +16,7 @@
 
 namespace canopen {
 
-PublishFunc::func_type PublishFunc::create(ros::NodeHandle &nh,  const std::string &name, canopen::NodeSharedPtr node, const std::string &key, bool force){
+PublishFunc::FuncType PublishFunc::create(ros::NodeHandle &nh,  const std::string &name, canopen::NodeSharedPtr node, const std::string &key, bool force){
     ObjectStorageSharedPtr s = node->getStorage();
 
     switch(ObjectDict::DataTypes(s->dict_->get(key)->data_type)){
@@ -142,7 +142,7 @@ bool RosChain::handle_recover(std_srvs::Trigger::Request  &req, std_srvs::Trigge
 void RosChain::handleWrite(LayerStatus &status, const LayerState &current_state) {
     LayerStack::handleWrite(status, current_state);
     if(current_state > Shutdown){
-        for(std::vector<boost::function<void() > >::iterator it = publishers_.begin(); it != publishers_.end(); ++it) (*it)();
+        for(std::vector<PublishFunc::FuncType>::iterator it = publishers_.begin(); it != publishers_.end(); ++it) (*it)();
     }
 }
 
@@ -485,7 +485,7 @@ bool RosChain::setup_nodes(){
                 for(int i = 0; i < objs.size(); ++i){
                     std::pair<std::string, bool> obj_name = parseObjectName(objs[i]);
 
-                    boost::function<void()> pub = PublishFunc::create(nh_, node_name +"_"+obj_name.first, node, obj_name.first, obj_name.second);
+                    PublishFunc::FuncType pub = PublishFunc::create(nh_, node_name +"_"+obj_name.first, node, obj_name.first, obj_name.second);
                     if(!pub){
                         ROS_ERROR_STREAM("Could not create publisher for '" << obj_name.first << "'");
                         return false;

--- a/canopen_chain_node/src/ros_chain.cpp
+++ b/canopen_chain_node/src/ros_chain.cpp
@@ -263,7 +263,7 @@ bool RosChain::setup_bus(){
         return false;
     }
 
-    add(boost::make_shared<CANLayer>(interface_, can_device, loopback));
+    add(make_shared<CANLayer>(interface_, can_device, loopback));
 
     return true;
 }
@@ -464,9 +464,9 @@ bool RosChain::setup_nodes(){
             ROS_ERROR_STREAM("EDS '" << eds << "' could not be parsed");
             return false;
         }
-        canopen::NodeSharedPtr node = boost::make_shared<canopen::Node>(interface_, dict, node_id, sync_);
+        canopen::NodeSharedPtr node = make_shared<canopen::Node>(interface_, dict, node_id, sync_);
 
-        LoggerSharedPtr logger = boost::make_shared<Logger>(node);
+        LoggerSharedPtr logger = make_shared<Logger>(node);
 
         if(!nodeAdded(merged, node, logger)) return false;
 
@@ -501,7 +501,7 @@ bool RosChain::setup_nodes(){
         nodes_->add(node);
         nodes_lookup_.insert(std::make_pair(node_name, node));
 
-        boost::shared_ptr<canopen::EMCYHandler> emcy = boost::make_shared<canopen::EMCYHandler>(interface_, node->getStorage());
+        boost::shared_ptr<canopen::EMCYHandler> emcy = make_shared<canopen::EMCYHandler>(interface_, node->getStorage());
         emcy_handlers_->add(emcy);
         logger->add(emcy);
 

--- a/canopen_chain_node/src/ros_chain.cpp
+++ b/canopen_chain_node/src/ros_chain.cpp
@@ -16,8 +16,8 @@
 
 namespace canopen {
 
-PublishFunc::func_type PublishFunc::create(ros::NodeHandle &nh,  const std::string &name, boost::shared_ptr<canopen::Node> node, const std::string &key, bool force){
-    boost::shared_ptr<ObjectStorage> s = node->getStorage();
+PublishFunc::func_type PublishFunc::create(ros::NodeHandle &nh,  const std::string &name, canopen::NodeSharedPtr node, const std::string &key, bool force){
+    ObjectStorageSharedPtr s = node->getStorage();
 
     switch(ObjectDict::DataTypes(s->dict_->get(key)->data_type)){
         case ObjectDict::DEFTYPE_INTEGER8:       return create< std_msgs::Int8    >(nh, name, s->entry<ObjectStorage::DataType<ObjectDict::DEFTYPE_INTEGER8>::type>(key), force);
@@ -43,7 +43,7 @@ PublishFunc::func_type PublishFunc::create(ros::NodeHandle &nh,  const std::stri
 }
 
 void RosChain::logState(const can::State &s){
-    boost::shared_ptr<can::DriverInterface> interface = interface_;
+    can::DriverInterfaceSharedPtr interface = interface_;
     std::string msg;
     if(interface && !interface->translateError(s.internal_error, msg)) msg  =  "Undefined"; ;
     ROS_INFO_STREAM("Current state: " << s.driver_state << " device error: " << s.error_code << " internal_error: " << s.internal_error << " (" << msg << ")");
@@ -186,7 +186,7 @@ bool RosChain::handle_halt(std_srvs::Trigger::Request  &req, std_srvs::Trigger::
 }
 
 bool RosChain::handle_get_object(canopen_chain_node::GetObject::Request  &req, canopen_chain_node::GetObject::Response &res){
-    std::map<std::string, boost::shared_ptr<canopen::Node> >::iterator it = nodes_lookup_.find(req.node);
+    std::map<std::string, canopen::NodeSharedPtr >::iterator it = nodes_lookup_.find(req.node);
     if(it == nodes_lookup_.end()){
         res.message = "node not found";
     }else{
@@ -201,7 +201,7 @@ bool RosChain::handle_get_object(canopen_chain_node::GetObject::Request  &req, c
 }
 
 bool RosChain::handle_set_object(canopen_chain_node::SetObject::Request  &req, canopen_chain_node::SetObject::Response &res){
-    std::map<std::string, boost::shared_ptr<canopen::Node> >::iterator it = nodes_lookup_.find(req.node);
+    std::map<std::string, canopen::NodeSharedPtr >::iterator it = nodes_lookup_.find(req.node);
     if(it == nodes_lookup_.end()){
         res.message = "node not found";
     }else{
@@ -459,14 +459,14 @@ bool RosChain::setup_nodes(){
         catch(...){
         }
 
-        boost::shared_ptr<ObjectDict>  dict = ObjectDict::fromFile(eds, overlay);
+        ObjectDictSharedPtr  dict = ObjectDict::fromFile(eds, overlay);
         if(!dict){
             ROS_ERROR_STREAM("EDS '" << eds << "' could not be parsed");
             return false;
         }
-        boost::shared_ptr<canopen::Node> node = boost::make_shared<canopen::Node>(interface_, dict, node_id, sync_);
+        canopen::NodeSharedPtr node = boost::make_shared<canopen::Node>(interface_, dict, node_id, sync_);
 
-        boost::shared_ptr<Logger> logger = boost::make_shared<Logger>(node);
+        LoggerSharedPtr logger = boost::make_shared<Logger>(node);
 
         if(!nodeAdded(merged, node, logger)) return false;
 
@@ -508,7 +508,7 @@ bool RosChain::setup_nodes(){
     }
     return true;
 }
-bool RosChain::nodeAdded(XmlRpc::XmlRpcValue &params, const boost::shared_ptr<canopen::Node> &node, const boost::shared_ptr<Logger> &logger){
+bool RosChain::nodeAdded(XmlRpc::XmlRpcValue &params, const canopen::NodeSharedPtr &node, const LoggerSharedPtr &logger){
     return true;
 }
 

--- a/canopen_chain_node/src/sync_node.cpp
+++ b/canopen_chain_node/src/sync_node.cpp
@@ -63,7 +63,7 @@ int main(int argc, char** argv){
         return 1;
     }
 
-    boost::shared_ptr<can::SocketCANDriver> driver = boost::make_shared<can::SocketCANDriver>();
+    can::SocketCANDriverSharedPtr driver = boost::make_shared<can::SocketCANDriver>();
     canopen::SyncProperties sync_properties(can::MsgHeader(sync_nh.param("sync_id", 0x080)), sync_ms, sync_overflow);
 
     boost::shared_ptr<canopen::BCMsync> sync = boost::make_shared<canopen::BCMsync>(can_device, driver, sync_properties);

--- a/canopen_chain_node/src/sync_node.cpp
+++ b/canopen_chain_node/src/sync_node.cpp
@@ -63,10 +63,10 @@ int main(int argc, char** argv){
         return 1;
     }
 
-    can::SocketCANDriverSharedPtr driver = boost::make_shared<can::SocketCANDriver>();
+    can::SocketCANDriverSharedPtr driver = can::make_shared<can::SocketCANDriver>();
     canopen::SyncProperties sync_properties(can::MsgHeader(sync_nh.param("sync_id", 0x080)), sync_ms, sync_overflow);
 
-    boost::shared_ptr<canopen::BCMsync> sync = boost::make_shared<canopen::BCMsync>(can_device, driver, sync_properties);
+    boost::shared_ptr<canopen::BCMsync> sync = canopen::make_shared<canopen::BCMsync>(can_device, driver, sync_properties);
 
     std::vector<int> nodes;
 
@@ -86,7 +86,7 @@ int main(int argc, char** argv){
 
     canopen::LayerStack stack("SyncNodeLayer");
 
-    stack.add(boost::make_shared<canopen::CANLayer>(driver, can_device, false));
+    stack.add(canopen::make_shared<canopen::CANLayer>(driver, can_device, false));
     stack.add(sync);
 
     diagnostic_updater::Updater diag_updater(nh, nh_priv);

--- a/canopen_master/include/canopen_master/bcm_sync.h
+++ b/canopen_master/include/canopen_master/bcm_sync.h
@@ -30,9 +30,9 @@ class BCMsync : public Layer {
 
     bool sync_running_;
     can::BCMsocket bcm_;
-    boost::shared_ptr<can::SocketCANDriver>  driver_;
+    can::SocketCANDriverSharedPtr  driver_;
     uint16_t sync_ms_;
-    can::CommInterface::FrameListener::Ptr handler_;
+    can::FrameListenerConstSharedPtr handler_;
 
     std::vector<can::Frame> sync_frames_;
 
@@ -64,7 +64,7 @@ class BCMsync : public Layer {
             int id = frame.id & ALL_NODES_MASK;
             if(skipNode(id)) return;
 
-            if(frame.dlc > 0 && frame.data[0] ==  canopen::Node::Stopped) started_nodes_.erase(id); 
+            if(frame.dlc > 0 && frame.data[0] ==  canopen::Node::Stopped) started_nodes_.erase(id);
         }
 
         // toggle sync if needed
@@ -91,7 +91,7 @@ protected:
         report.add("known_nodes", join(known_nodes_, ", "));
         report.add("started_nodes", join(started_nodes_, ", "));
     }
- 
+
     virtual void handleInit(LayerStatus &status){
         boost::mutex::scoped_lock lock(mutex_);
         started_nodes_.clear();
@@ -125,7 +125,7 @@ protected:
     virtual void handleHalt(LayerStatus &status) {
         boost::mutex::scoped_lock lock(mutex_);
         if(sync_running_){
-            bcm_.stopTX(sync_frames_.front());        
+            bcm_.stopTX(sync_frames_.front());
             sync_running_ = false;
             started_nodes_.clear();
         }
@@ -140,7 +140,7 @@ public:
     static const uint32_t HEARTBEAT_ID = 0x700;
     static const uint32_t NMT_ID = 0x000;
 
-    BCMsync(const std::string &device, boost::shared_ptr<can::SocketCANDriver>  driver, const SyncProperties &sync_properties)
+    BCMsync(const std::string &device, can::SocketCANDriverSharedPtr  driver, const SyncProperties &sync_properties)
     : Layer(device + " SyncLayer"), device_(device), sync_running_(false), sync_ms_(sync_properties.period_ms_), driver_(driver) {
         if(sync_properties.overflow_ == 0){
             sync_frames_.resize(1);

--- a/canopen_master/include/canopen_master/can_layer.h
+++ b/canopen_master/include/canopen_master/can_layer.h
@@ -8,11 +8,11 @@ namespace canopen{
 
 class CANLayer: public Layer{
     boost::mutex mutex_;
-    boost::shared_ptr<can::DriverInterface> driver_;
+    can::DriverInterfaceSharedPtr driver_;
     const std::string device_;
     const bool loopback_;
     can::Frame last_error_;
-    can::CommInterface::FrameListener::Ptr error_listener_;
+    can::FrameListenerConstSharedPtr error_listener_;
     void handleFrame(const can::Frame & msg){
         boost::mutex::scoped_lock lock(mutex_);
         last_error_ = msg;
@@ -21,7 +21,7 @@ class CANLayer: public Layer{
     boost::shared_ptr<boost::thread> thread_;
 
 public:
-    CANLayer(const boost::shared_ptr<can::DriverInterface> &driver, const std::string &device, bool loopback)
+    CANLayer(const can::DriverInterfaceSharedPtr &driver, const std::string &device, bool loopback)
     : Layer(device + " Layer"), driver_(driver), device_(device), loopback_(loopback) { assert(driver_); }
 
     virtual void handleRead(LayerStatus &status, const LayerState &current_state) {

--- a/canopen_master/include/canopen_master/canopen.h
+++ b/canopen_master/include/canopen_master/canopen.h
@@ -58,7 +58,7 @@ public:
     void init();
 
     SDOClient(const can::CommInterfaceSharedPtr interface, const ObjectDictSharedPtr dict, uint8_t node_id)
-    : interface_(interface), storage_(boost::make_shared<ObjectStorage>(dict, node_id, ObjectStorage::ReadDelegate(this, &SDOClient::read), ObjectStorage::WriteDelegate(this, &SDOClient::write))), reader_(false, 1)
+    : interface_(interface), storage_(make_shared<ObjectStorage>(dict, node_id, ObjectStorage::ReadDelegate(this, &SDOClient::read), ObjectStorage::WriteDelegate(this, &SDOClient::write))), reader_(false, 1)
     {
     }
 };

--- a/canopen_master/include/canopen_master/objdict.h
+++ b/canopen_master/include/canopen_master/objdict.h
@@ -13,6 +13,8 @@
 
 namespace canopen{
 
+using boost::make_shared;
+
 class TypeGuard{
     const std::type_info& (*get_type)();
     size_t type_size;
@@ -461,10 +463,10 @@ public:
 
             if(!e->def_val.is_empty()){
                 T val = NodeIdOffset<T>::apply(e->def_val, node_id_);
-                data = boost::make_shared<Data>(key, e,val, read_delegate_, write_delegate_);
+                data = make_shared<Data>(key, e,val, read_delegate_, write_delegate_);
             }else{
                 if(!e->def_val.type().valid() ||  e->def_val.type() == type) {
-                    data = boost::make_shared<Data>(key,e,type, read_delegate_, write_delegate_);
+                    data = make_shared<Data>(key,e,type, read_delegate_, write_delegate_);
                 }else{
                     THROW_WITH_KEY(std::bad_cast(), key);
                 }

--- a/canopen_master/include/canopen_master/objdict.h
+++ b/canopen_master/include/canopen_master/objdict.h
@@ -505,8 +505,10 @@ public:
             return false;
         }
     }
-     boost::function<std::string()> getStringReader(const ObjectDict::Key &key, bool cached = false);
-     boost::function<void(const std::string &)> getStringWriter(const ObjectDict::Key &key, bool cached = false);
+    typedef boost::function<std::string()> ReadStringFuncType;
+    ReadStringFuncType getStringReader(const ObjectDict::Key &key, bool cached = false);
+    typedef boost::function<void(const std::string &)>  WriteStringFuncType;
+    WriteStringFuncType getStringWriter(const ObjectDict::Key &key, bool cached = false);
 
     const ObjectDictConstSharedPtr dict_;
     const uint8_t node_id_;

--- a/canopen_master/include/canopen_master/objdict.h
+++ b/canopen_master/include/canopen_master/objdict.h
@@ -2,12 +2,12 @@
 #define H_OBJDICT
 
 #include <socketcan_interface/FastDelegate.h>
-#include <boost/unordered_map.hpp>    
-#include <boost/unordered_set.hpp>    
-#include <boost/thread/mutex.hpp>    
+#include <boost/unordered_map.hpp>
+#include <boost/unordered_set.hpp>
+#include <boost/thread/mutex.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/function.hpp>
-#include <typeinfo> 
+#include <typeinfo>
 #include <vector>
 #include "exceptions.h"
 
@@ -27,11 +27,11 @@ public:
     template<typename T> bool is_type() const {
         return valid() && get_type() == typeid(T);
     }
-    
+
     bool operator==(const TypeGuard &other) const {
         return valid() && other.valid() && (get_type() == other.get_type());
     }
-    
+
     TypeGuard(): get_type(0), type_size(0) {}
     bool valid() const { return get_type != 0; }
     size_t get_size() const { return type_size; }
@@ -56,9 +56,9 @@ class HoldAny{
     bool empty;
 public:
     HoldAny() : empty(true) {}
-    
+
     const TypeGuard& type() const{ return type_guard; }
-    
+
     template<typename T> HoldAny(const T &t) : type_guard(TypeGuard::create<T>()), empty(false){
         buffer.resize(sizeof(T));
         *(T*)&(buffer.front()) = t;
@@ -72,11 +72,11 @@ public:
     HoldAny(const TypeGuard &t): type_guard(t), empty(true){ }
 
     bool is_empty() const { return empty; }
-    
-    const String& data() const { 
+
+    const String& data() const {
         if(empty){
             BOOST_THROW_EXCEPTION(std::length_error("buffer empty"));
-        }        
+        }
         return buffer;
     }
 
@@ -166,26 +166,28 @@ public:
         std::string desc;
         HoldAny def_val;
         HoldAny init_val;
-        
+
         Entry() {}
-        
+
         Entry(const Code c, const uint16_t i,  const uint16_t t, const std::string & d, const bool r = true, const bool w = true, bool m = false, const HoldAny def = HoldAny(), const HoldAny init = HoldAny()):
         obj_code(c), index(i), sub_index(0),data_type(t),readable(r), writable(w), mappable(m), desc(d), def_val(def), init_val(init) {}
-        
+
         Entry(const uint16_t i, const uint8_t s, const uint16_t t, const std::string & d, const bool r = true, const bool w = true, bool m = false, const HoldAny def = HoldAny(), const HoldAny init = HoldAny()):
         obj_code(VAR), index(i), sub_index(s),data_type(t),readable(r), writable(w), mappable(m), desc(d), def_val(def), init_val(init) {}
-        
+
         operator Key() const { return Key(index, sub_index); }
         const HoldAny & value() const { return !init_val.is_empty() ? init_val : def_val; }
-            
+
     };
+    typedef boost::shared_ptr<const Entry> EntryConstSharedPtr;
+
     const Entry& operator()(uint16_t i) const{
         return *at(Key(i));
     }
     const Entry& operator()(uint16_t i, uint8_t s) const{
         return *at(Key(i,s));
     }
-    const boost::shared_ptr<const Entry>& get(const Key &k) const{
+    const EntryConstSharedPtr& get(const Key &k) const{
         return at(k);
     }
     bool has(uint16_t i, uint8_t s) const{
@@ -197,19 +199,20 @@ public:
     bool has(const Key &k) const{
         return dict_.find(k) != dict_.end();
     }
-    bool insert(bool is_sub, boost::shared_ptr<const Entry> e){
-        std::pair<boost::unordered_map<Key, boost::shared_ptr<const Entry> >::iterator, bool>  res = dict_.insert(std::make_pair(is_sub?Key(e->index,e->sub_index):Key(e->index),e));
+    bool insert(bool is_sub, EntryConstSharedPtr e){
+        std::pair<boost::unordered_map<Key, EntryConstSharedPtr>::iterator, bool>  res = dict_.insert(std::make_pair(is_sub?Key(e->index,e->sub_index):Key(e->index),e));
         return res.second;
     }
-    bool iterate(boost::unordered_map<Key, boost::shared_ptr<const Entry> >::const_iterator &it) const;
+    bool iterate(boost::unordered_map<Key, EntryConstSharedPtr>::const_iterator &it) const;
     typedef std::list<std::pair<std::string, std::string> > Overlay;
-    static boost::shared_ptr<ObjectDict> fromFile(const std::string &path, const Overlay &overlay = Overlay());
+    typedef boost::shared_ptr<ObjectDict> ObjectDictSharedPtr;
+    static ObjectDictSharedPtr fromFile(const std::string &path, const Overlay &overlay = Overlay());
     const DeviceInfo device_info;
-    
+
     ObjectDict(const DeviceInfo &info): device_info(info) {}
     typedef boost::error_info<struct tag_objectdict_key, ObjectDict::Key> key_info;
 protected:
-    const boost::shared_ptr<const Entry>& at(const Key &key) const{
+    const EntryConstSharedPtr& at(const Key &key) const{
         try{
             return dict_.at(key);
         }
@@ -218,33 +221,35 @@ protected:
         }
     }
 
-    boost::unordered_map<Key, boost::shared_ptr<const Entry> > dict_;
+    boost::unordered_map<Key, EntryConstSharedPtr > dict_;
 };
+typedef ObjectDict::ObjectDictSharedPtr ObjectDictSharedPtr;
+typedef boost::shared_ptr<const ObjectDict> ObjectDictConstSharedPtr;
 
 std::size_t hash_value(ObjectDict::Key const& k);
 
 template<typename T> class NodeIdOffset{
     T offset;
     T (*adder)(const uint8_t &, const T &);
-    
+
     static T add(const uint8_t &u, const T &t) {
         return u+t;
     }
 public:
     NodeIdOffset(const T &t): offset(t), adder(add) {}
-    
+
     static const T apply(const HoldAny &val, const uint8_t &u){
         if(!val.is_empty()){
             if(TypeGuard::create<T>() ==  val.type() ){
                 return val.get<T>();
             }else{
-                const NodeIdOffset<T> &no = val.get< NodeIdOffset<T> >();                
+                const NodeIdOffset<T> &no = val.get< NodeIdOffset<T> >();
                 return no.adder(u, no.offset);
             }
         }else{
             BOOST_THROW_EXCEPTION(std::bad_cast());
         }
-        
+
     }
 };
 
@@ -258,13 +263,14 @@ class AccessException : public Exception{
 public:
     AccessException(const std::string &w) : Exception(w) {}
 };
- 
- 
+
+
 class ObjectStorage{
 public:
     typedef fastdelegate::FastDelegate2<const ObjectDict::Entry&, String &> ReadDelegate;
     typedef fastdelegate::FastDelegate2<const ObjectDict::Entry&, const String &> WriteDelegate;
-    
+    typedef boost::shared_ptr<ObjectStorage> ObjectStorageSharedPtr;
+
 protected:
     class Data: boost::noncopyable{
         boost::mutex mutex;
@@ -273,7 +279,7 @@ protected:
 
         ReadDelegate read_delegate;
         WriteDelegate write_delegate;
-        
+
         template <typename T> T & access(){
             if(!valid){
                 THROW_WITH_KEY(std::length_error("buffer not valid"), key);
@@ -289,18 +295,18 @@ protected:
         }
     public:
         const TypeGuard type_guard;
-        const boost::shared_ptr<const ObjectDict::Entry> entry;
+        const ObjectDict::EntryConstSharedPtr entry;
         const ObjectDict::Key key;
         size_t size() { boost::mutex::scoped_lock lock(mutex); return buffer.size(); }
-        
-        template<typename T> Data(const ObjectDict::Key &k, const boost::shared_ptr<const ObjectDict::Entry> &e, const T &val, const ReadDelegate &r, const WriteDelegate &w)
+
+        template<typename T> Data(const ObjectDict::Key &k, const ObjectDict::EntryConstSharedPtr &e, const T &val, const ReadDelegate &r, const WriteDelegate &w)
         : valid(false), read_delegate(r), write_delegate(w), type_guard(TypeGuard::create<T>()), entry(e), key(k){
             assert(!r.empty());
             assert(!w.empty());
             assert(e);
             allocate<T>() = val;
         }
-        Data(const ObjectDict::Key &k, const boost::shared_ptr<const ObjectDict::Entry> &e, const TypeGuard &t, const ReadDelegate &r, const WriteDelegate &w)
+        Data(const ObjectDict::Key &k, const ObjectDict::EntryConstSharedPtr &e, const TypeGuard &t, const ReadDelegate &r, const WriteDelegate &w)
         : valid(false), read_delegate(r), write_delegate(w), type_guard(t), entry(e), key(k){
             assert(!r.empty());
             assert(!w.empty());
@@ -315,14 +321,14 @@ protected:
         }
         template<typename T> const T get(bool cached) {
             boost::mutex::scoped_lock lock(mutex);
-            
+
             if(!entry->readable){
                 THROW_WITH_KEY(AccessException("no read access"), key);
 
             }
-            
+
             if(entry->constant) cached = true;
-            
+
             if(!valid || !cached){
                 allocate<T>();
                 read_delegate(*entry, buffer);
@@ -331,7 +337,7 @@ protected:
         }
         template<typename T>  void set(const T &val) {
             boost::mutex::scoped_lock lock(mutex);
-            
+
             if(!entry->writable){
                 if(access<T>() != val){
                     THROW_WITH_KEY(AccessException("no write access"), key);
@@ -356,15 +362,15 @@ protected:
         void reset();
         void force_write();
 
-    };        
-        
+    };
+    typedef boost::shared_ptr<Data> DataSharedPtr;
 public:
     template<const uint16_t dt> struct DataType{
         typedef void type;
     };
-    
+
     template<typename T> class Entry{
-        boost::shared_ptr<Data> data;
+        DataSharedPtr data;
     public:
         typedef T type;
         bool valid() const { return data != 0; }
@@ -372,7 +378,7 @@ public:
             if(!data) BOOST_THROW_EXCEPTION( PointerInvalid("ObjectStorage::Entry::get()") );
 
             return data->get<T>(false);
-        }    
+        }
         bool get(T & val){
             try{
                 val = get();
@@ -380,12 +386,12 @@ public:
             }catch(...){
                 return false;
             }
-        }    
+        }
         const T get_cached() {
             if(!data) BOOST_THROW_EXCEPTION( PointerInvalid("ObjectStorage::Entry::get_cached()") );
 
             return data->get<T>(true);
-        }        
+        }
         bool get_cached(T & val){
             try{
                 val = get_cached();
@@ -393,7 +399,7 @@ public:
             }catch(...){
                 return false;
             }
-        }    
+        }
         void set(const T &val) {
             if(!data) BOOST_THROW_EXCEPTION( PointerInvalid("ObjectStorage::Entry::set(val)") );
             data->set(val);
@@ -407,21 +413,21 @@ public:
                 return false;
             }
         }
- 
+
         Entry() {}
-        Entry(boost::shared_ptr<Data> &d)
+        Entry(DataSharedPtr &d)
         : data(d){
             assert(data);
         }
-        Entry(boost::shared_ptr<ObjectStorage> storage, uint16_t index)
+        Entry(ObjectStorageSharedPtr storage, uint16_t index)
         : data(storage->entry<type>(index).data) {
             assert(data);
         }
-        Entry(boost::shared_ptr<ObjectStorage> storage, uint16_t index, uint8_t sub_index)
+        Entry(ObjectStorageSharedPtr storage, uint16_t index, uint8_t sub_index)
         : data(storage->entry<type>(index, sub_index).data) {
             assert(data);
         }
-        Entry(boost::shared_ptr<ObjectStorage> storage, const ObjectDict::Key &k)
+        Entry(ObjectStorageSharedPtr storage, const ObjectDict::Key &k)
         : data(storage->entry<type>(k).data) {
             assert(data);
         }
@@ -429,30 +435,30 @@ public:
             return *(data->entry);
         }
     };
-    
+
     void reset();
-    
+
 protected:
-    boost::unordered_map<ObjectDict::Key, boost::shared_ptr<Data> > storage_;
+    boost::unordered_map<ObjectDict::Key, DataSharedPtr > storage_;
     boost::mutex mutex_;
-    
-    void init_nolock(const ObjectDict::Key &key, const boost::shared_ptr<const ObjectDict::Entry> &entry);
-    
+
+    void init_nolock(const ObjectDict::Key &key, const ObjectDict::EntryConstSharedPtr &entry);
+
     ReadDelegate read_delegate_;
     WriteDelegate write_delegate_;
-    size_t map(const boost::shared_ptr<const ObjectDict::Entry> &e, const ObjectDict::Key &key, const ReadDelegate & read_delegate, const WriteDelegate & write_delegate);
+    size_t map(const ObjectDict::EntryConstSharedPtr &e, const ObjectDict::Key &key, const ReadDelegate & read_delegate, const WriteDelegate & write_delegate);
 public:
     template<typename T> Entry<T> entry(const ObjectDict::Key &key){
         boost::mutex::scoped_lock lock(mutex_);
-        
-        boost::unordered_map<ObjectDict::Key, boost::shared_ptr<Data> >::iterator it = storage_.find(key);
-        
+
+        boost::unordered_map<ObjectDict::Key, DataSharedPtr >::iterator it = storage_.find(key);
+
         if(it == storage_.end()){
-            const boost::shared_ptr<const ObjectDict::Entry> e = dict_->get(key);
-            
-            boost::shared_ptr<Data> data;
+            const ObjectDict::EntryConstSharedPtr e = dict_->get(key);
+
+            DataSharedPtr data;
             TypeGuard type = TypeGuard::create<T>();
-    
+
             if(!e->def_val.is_empty()){
                 T val = NodeIdOffset<T>::apply(e->def_val, node_id_);
                 data = boost::make_shared<Data>(key, e,val, read_delegate_, write_delegate_);
@@ -463,11 +469,11 @@ public:
                     THROW_WITH_KEY(std::bad_cast(), key);
                 }
             }
-            
-            std::pair<boost::unordered_map<ObjectDict::Key, boost::shared_ptr<Data> >::iterator, bool>  ok = storage_.insert(std::make_pair(key, data));
+
+            std::pair<boost::unordered_map<ObjectDict::Key, DataSharedPtr >::iterator, bool>  ok = storage_.insert(std::make_pair(key, data));
             it = ok.first;
         }
-        
+
         if(!it->second->type_guard.is_type<T>()){
             THROW_WITH_KEY(std::bad_cast(), key);
         }
@@ -475,14 +481,14 @@ public:
     }
 
     size_t map(uint16_t index, uint8_t sub_index, const ReadDelegate & read_delegate, const WriteDelegate & write_delegate);
-    
+
     template<typename T> Entry<T> entry(uint16_t index){
         return entry<T>(ObjectDict::Key(index));
     }
     template<typename T> Entry<T> entry(uint16_t index, uint8_t sub_index){
         return entry<T>(ObjectDict::Key(index,sub_index));
     }
-    
+
     template<typename T> void entry(Entry<T> &e, uint16_t index){ // TODO: migrate to bool
         e = entry<T>(ObjectDict::Key(index));
     }
@@ -500,14 +506,15 @@ public:
      boost::function<std::string()> getStringReader(const ObjectDict::Key &key, bool cached = false);
      boost::function<void(const std::string &)> getStringWriter(const ObjectDict::Key &key, bool cached = false);
 
-    const boost::shared_ptr<const ObjectDict> dict_;
+    const ObjectDictConstSharedPtr dict_;
     const uint8_t node_id_;
-    
-    ObjectStorage(boost::shared_ptr<const ObjectDict> dict, uint8_t node_id, ReadDelegate read_delegate, WriteDelegate write_delegate);
-    
+
+    ObjectStorage(ObjectDictConstSharedPtr dict, uint8_t node_id, ReadDelegate read_delegate, WriteDelegate write_delegate);
+
     void init(const ObjectDict::Key &key);
     void init_all();
 };
+typedef ObjectStorage::ObjectStorageSharedPtr ObjectStorageSharedPtr;
 
 template<> String & ObjectStorage::Data::access();
 template<> String & ObjectStorage::Data::allocate();
@@ -536,12 +543,12 @@ template<typename T, typename R> static R *branch_type(const uint16_t data_type)
         case ObjectDict::DEFTYPE_INTEGER16: return T::template func< ObjectDict::DEFTYPE_INTEGER16 >;
         case ObjectDict::DEFTYPE_INTEGER32: return T::template func< ObjectDict::DEFTYPE_INTEGER32 >;
         case ObjectDict::DEFTYPE_INTEGER64: return T::template func< ObjectDict::DEFTYPE_INTEGER64 >;
-            
+
         case ObjectDict::DEFTYPE_UNSIGNED8: return T::template func< ObjectDict::DEFTYPE_UNSIGNED8 >;
         case ObjectDict::DEFTYPE_UNSIGNED16: return T::template func< ObjectDict::DEFTYPE_UNSIGNED16 >;
         case ObjectDict::DEFTYPE_UNSIGNED32: return T::template func< ObjectDict::DEFTYPE_UNSIGNED32 >;
         case ObjectDict::DEFTYPE_UNSIGNED64: return T::template func< ObjectDict::DEFTYPE_UNSIGNED64 >;
-            
+
         case ObjectDict::DEFTYPE_REAL32: return T::template func< ObjectDict::DEFTYPE_REAL32 >;
         case ObjectDict::DEFTYPE_REAL64: return T::template func< ObjectDict::DEFTYPE_REAL64 >;
 
@@ -549,7 +556,7 @@ template<typename T, typename R> static R *branch_type(const uint16_t data_type)
         case ObjectDict::DEFTYPE_OCTET_STRING: return T::template func< ObjectDict::DEFTYPE_OCTET_STRING >;
         case ObjectDict::DEFTYPE_UNICODE_STRING: return T::template func< ObjectDict::DEFTYPE_UNICODE_STRING >;
         case ObjectDict::DEFTYPE_DOMAIN: return T::template func< ObjectDict::DEFTYPE_DOMAIN >;
-           
+
         default:
             throw std::bad_cast();
     }

--- a/canopen_master/src/bcm_sync.cpp
+++ b/canopen_master/src/bcm_sync.cpp
@@ -42,7 +42,7 @@ int main(int argc, char** argv){
         }
     }
 
-    can::SocketCANDriverSharedPtr driver = boost::make_shared<can::SocketCANDriver>();
+    can::SocketCANDriverSharedPtr driver = can::make_shared<can::SocketCANDriver>();
     if(!driver->init(can_device, false)){
         std::cout << "Could not initialize CAN" << std::endl;
         return 1;
@@ -60,7 +60,7 @@ int main(int argc, char** argv){
         std::cout << "Could not initialize sync" << std::endl;
         return 1;
     }
-    
+
     driver->run();
 
     return 0;

--- a/canopen_master/src/bcm_sync.cpp
+++ b/canopen_master/src/bcm_sync.cpp
@@ -42,7 +42,7 @@ int main(int argc, char** argv){
         }
     }
 
-    boost::shared_ptr<can::SocketCANDriver> driver = boost::make_shared<can::SocketCANDriver>();
+    can::SocketCANDriverSharedPtr driver = boost::make_shared<can::SocketCANDriver>();
     if(!driver->init(can_device, false)){
         std::cout << "Could not initialize CAN" << std::endl;
         return 1;

--- a/canopen_master/src/emcy.cpp
+++ b/canopen_master/src/emcy.cpp
@@ -46,7 +46,7 @@ void EMCYHandler::handleEMCY(const can::Frame & msg){
     has_error_ = (em.data.error_register & ~32) != 0;
 }
 
-EMCYHandler::EMCYHandler(const boost::shared_ptr<can::CommInterface> interface, const boost::shared_ptr<ObjectStorage> storage): Layer("EMCY handler"), storage_(storage), has_error_(true){
+EMCYHandler::EMCYHandler(const can::CommInterfaceSharedPtr interface, const ObjectStorageSharedPtr storage): Layer("EMCY handler"), storage_(storage), has_error_(true){
     storage_->entry(error_register_, 0x1001);
     try{
         storage_->entry(num_errors_, 0x1003,0);

--- a/canopen_master/src/master_plugin.cpp
+++ b/canopen_master/src/master_plugin.cpp
@@ -8,7 +8,7 @@ namespace canopen {
 
 class ManagingSyncLayer: public SyncLayer {
 protected:
-    boost::shared_ptr<can::CommInterface> interface_;
+    can::CommInterfaceSharedPtr interface_;
     boost::chrono::milliseconds step_, half_step_;
 
     std::set<void *> nodes_;
@@ -23,7 +23,7 @@ protected:
     virtual void handleRecover(LayerStatus &status)  { /* TODO */ }
 
 public:
-    ManagingSyncLayer(const SyncProperties &p, boost::shared_ptr<can::CommInterface> interface)
+    ManagingSyncLayer(const SyncProperties &p, can::CommInterfaceSharedPtr interface)
     : SyncLayer(p), interface_(interface), step_(p.period_ms_), half_step_(p.period_ms_/2), nodes_size_(0)
     {
     }
@@ -66,7 +66,7 @@ protected:
         read_time_ = get_abs_time(half_step_);
     }
 public:
-    SimpleSyncLayer(const SyncProperties &p, boost::shared_ptr<can::CommInterface> interface)
+    SimpleSyncLayer(const SyncProperties &p, can::CommInterfaceSharedPtr interface)
     : ManagingSyncLayer(p, interface) {}
 };
 
@@ -88,22 +88,22 @@ protected:
         reader_.listen(interface_, can::MsgHeader(properties.header_));
     }
 public:
-    ExternalSyncLayer(const SyncProperties &p, boost::shared_ptr<can::CommInterface> interface)
+    ExternalSyncLayer(const SyncProperties &p, can::CommInterfaceSharedPtr interface)
     : ManagingSyncLayer(p, interface), reader_(true,1) {}
 };
 
 
 template<typename SyncType> class WrapMaster: public Master{
-    boost::shared_ptr<can::CommInterface> interface_;
+    can::CommInterfaceSharedPtr interface_;
 public:
-    virtual boost::shared_ptr<SyncLayer> getSync(const SyncProperties &properties){
+    virtual SyncLayerSharedPtr getSync(const SyncProperties &properties){
         return boost::make_shared<SyncType>(properties, interface_);
     }
-    WrapMaster(boost::shared_ptr<can::CommInterface> interface) : interface_(interface)  {}
+    WrapMaster(can::CommInterfaceSharedPtr interface) : interface_(interface)  {}
 
     class Allocator : public Master::Allocator{
     public:
-        virtual boost::shared_ptr<Master> allocate(const std::string &name,  boost::shared_ptr<can::CommInterface> interface){
+        virtual MasterSharedPtr allocate(const std::string &name,  can::CommInterfaceSharedPtr interface){
             return boost::make_shared<WrapMaster>(interface);
         }
     };

--- a/canopen_master/src/master_plugin.cpp
+++ b/canopen_master/src/master_plugin.cpp
@@ -97,14 +97,14 @@ template<typename SyncType> class WrapMaster: public Master{
     can::CommInterfaceSharedPtr interface_;
 public:
     virtual SyncLayerSharedPtr getSync(const SyncProperties &properties){
-        return boost::make_shared<SyncType>(properties, interface_);
+        return make_shared<SyncType>(properties, interface_);
     }
     WrapMaster(can::CommInterfaceSharedPtr interface) : interface_(interface)  {}
 
     class Allocator : public Master::Allocator{
     public:
         virtual MasterSharedPtr allocate(const std::string &name,  can::CommInterfaceSharedPtr interface){
-            return boost::make_shared<WrapMaster>(interface);
+            return make_shared<WrapMaster>(interface);
         }
     };
 };

--- a/canopen_master/src/node.cpp
+++ b/canopen_master/src/node.cpp
@@ -27,7 +27,7 @@ struct NMTcommand{
 
 #pragma pack(pop) /* pop previous alignment from stack */
 
-Node::Node(const boost::shared_ptr<can::CommInterface> interface, const boost::shared_ptr<ObjectDict> dict, uint8_t node_id, const boost::shared_ptr<SyncCounter> sync)
+Node::Node(const can::CommInterfaceSharedPtr interface, const ObjectDictSharedPtr dict, uint8_t node_id, const SyncCounterSharedPtr sync)
 : Layer("Node 301"), node_id_(node_id), interface_(interface), sync_(sync) , state_(Unknown), sdo_(interface, dict, node_id), pdo_(interface){
     try{
         getStorage()->entry(heartbeat_, 0x1017);

--- a/canopen_master/src/objdict.cpp
+++ b/canopen_master/src/objdict.cpp
@@ -447,7 +447,7 @@ struct PrintValue {
     }
 };
 
-boost::function<std::string()> ObjectStorage::getStringReader(const ObjectDict::Key &key, bool cached){
+ObjectStorage::ReadStringFuncType ObjectStorage::getStringReader(const ObjectDict::Key &key, bool cached){
     return PrintValue::getReader(*this, key, cached);
 }
 
@@ -474,6 +474,6 @@ struct WriteStringValue {
     }
 };
 
-boost::function<void (const std::string&)> ObjectStorage::getStringWriter(const ObjectDict::Key &key, bool cached){
+ObjectStorage::WriteStringFuncType ObjectStorage::getStringWriter(const ObjectDict::Key &key, bool cached){
     return WriteStringValue::getWriter(*this, key, cached);
 }

--- a/canopen_master/src/objdict.cpp
+++ b/canopen_master/src/objdict.cpp
@@ -217,7 +217,7 @@ void parse_object(ObjectDictSharedPtr dict, boost::property_tree::iptree &pt, co
     boost::optional<boost::property_tree::iptree&> object =  pt.get_child_optional(name.substr(2));
     if(!object) return;
 
-    boost::shared_ptr<ObjectDict::Entry> entry = boost::make_shared<ObjectDict::Entry>();
+    boost::shared_ptr<ObjectDict::Entry> entry = make_shared<ObjectDict::Entry>();
     try{
         entry->index = int_from_string<uint16_t>(name);
         entry->obj_code = ObjectDict::Code(int_from_string<uint16_t>(object->get<std::string>("ObjectType", boost::lexical_cast<std::string>((uint16_t)ObjectDict::VAR))));
@@ -231,7 +231,7 @@ void parse_object(ObjectDictSharedPtr dict, boost::property_tree::iptree &pt, co
         }else if(entry->obj_code == ObjectDict::ARRAY || entry->obj_code == ObjectDict::RECORD){
             uint8_t subs = read_integer<uint8_t>(*object, "CompactSubObj");
             if(subs){ // compact
-                dict->insert(true, boost::make_shared<const canopen::ObjectDict::Entry>(entry->index, 0, ObjectDict::DEFTYPE_UNSIGNED8, "NrOfObjects", true, false, false, HoldAny(subs)));
+                dict->insert(true, make_shared<const canopen::ObjectDict::Entry>(entry->index, 0, ObjectDict::DEFTYPE_UNSIGNED8, "NrOfObjects", true, false, false, HoldAny(subs)));
 
                 read_var(*entry, *object);
 
@@ -239,7 +239,7 @@ void parse_object(ObjectDictSharedPtr dict, boost::property_tree::iptree &pt, co
                     std::string subname = pt.get<std::string>(name.substr(2)+"Name." + boost::lexical_cast<std::string>((int)i),entry->desc + boost::lexical_cast<std::string>((int)i));
                     subname = pt.get<std::string>(name.substr(2)+"Denotation." + boost::lexical_cast<std::string>((int)i), subname);
 
-                    dict->insert(true, boost::make_shared<const canopen::ObjectDict::Entry>(entry->index, i, entry->data_type, name, entry->readable, entry->writable, entry->mappable, entry->def_val,
+                    dict->insert(true, make_shared<const canopen::ObjectDict::Entry>(entry->index, i, entry->data_type, name, entry->readable, entry->writable, entry->mappable, entry->def_val,
                        ReadAnyValue::read_value(pt, entry->data_type, name.substr(2)+"Value." + boost::lexical_cast<std::string>((int)i))));
                 }
             }else{
@@ -318,7 +318,7 @@ ObjectDictSharedPtr ObjectDict::fromFile(const std::string &path, const ObjectDi
         }
     }
 
-    dict = boost::make_shared<ObjectDict>(info);
+    dict = make_shared<ObjectDict>(info);
 
     for(Overlay::const_iterator it= overlay.begin(); it != overlay.end(); ++it){
         pt.get_child(it->first).put("ParameterValue", it->second);
@@ -343,7 +343,7 @@ size_t ObjectStorage::map(const ObjectDict::EntryConstSharedPtr &e, const Object
             THROW_WITH_KEY(std::bad_cast() , key);
         }
 
-        data = boost::make_shared<Data>(key, e,e->def_val.type(),read_delegate_, write_delegate_);
+        data = make_shared<Data>(key, e,e->def_val.type(),read_delegate_, write_delegate_);
 
         std::pair<boost::unordered_map<ObjectDict::Key, DataSharedPtr >::iterator, bool>  ok = storage_.insert(std::make_pair(key, data));
         it = ok.first;
@@ -394,7 +394,7 @@ void ObjectStorage::init_nolock(const ObjectDict::Key &key, const ObjectDict::En
         boost::unordered_map<ObjectDict::Key, DataSharedPtr >::iterator it = storage_.find(key);
 
         if(it == storage_.end()){
-            DataSharedPtr data = boost::make_shared<Data>(key,entry, entry->init_val.type(), read_delegate_, write_delegate_);
+            DataSharedPtr data = make_shared<Data>(key,entry, entry->init_val.type(), read_delegate_, write_delegate_);
             std::pair<boost::unordered_map<ObjectDict::Key, DataSharedPtr >::iterator, bool>  ok = storage_.insert(std::make_pair(key, data));
             it = ok.first;
             if(!ok.second){

--- a/canopen_master/src/pdo.cpp
+++ b/canopen_master/src/pdo.cpp
@@ -121,7 +121,7 @@ void PDOMapper::PDO::parse_and_set_mapping(const ObjectStorageSharedPtr &storage
             if(!init.is_empty()) mapentry.set(init.get<uint32_t>());
 
             PDOmap param(mapentry.get_cached());
-            BufferSharedPtr b = boost::make_shared<Buffer>(param.length/8);
+            BufferSharedPtr b = make_shared<Buffer>(param.length/8);
             if(param.index < 0x1000){
                 // TODO: check DummyUsage
             }else{

--- a/canopen_motor_node/include/canopen_motor_node/controller_manager_layer.h
+++ b/canopen_motor_node/include/canopen_motor_node/controller_manager_layer.h
@@ -17,7 +17,7 @@ namespace canopen {
 
 class ControllerManagerLayer : public canopen::Layer {
     boost::shared_ptr<controller_manager::ControllerManager> cm_;
-    boost::shared_ptr<canopen::RobotLayer> robot_;
+    canopen::RobotLayerSharedPtr robot_;
     ros::NodeHandle nh_;
 
     canopen::time_point last_time_;
@@ -25,7 +25,7 @@ class ControllerManagerLayer : public canopen::Layer {
     const ros::Duration fixed_period_;
 
 public:
-    ControllerManagerLayer(const boost::shared_ptr<canopen::RobotLayer> robot, const ros::NodeHandle &nh, const ros::Duration &fixed_period)
+    ControllerManagerLayer(const canopen::RobotLayerSharedPtr robot, const ros::NodeHandle &nh, const ros::Duration &fixed_period)
     :Layer("ControllerManager"), robot_(robot), nh_(nh), fixed_period_(fixed_period) {
     }
 

--- a/canopen_motor_node/include/canopen_motor_node/handle_layer.h
+++ b/canopen_motor_node/include/canopen_motor_node/handle_layer.h
@@ -23,12 +23,12 @@ public:
     virtual void enforce(const ros::Duration &period) = 0;
     virtual void reset() = 0;
     virtual ~LimitsHandleBase();
-    typedef boost::shared_ptr<LimitsHandleBase> Ptr;
+    typedef boost::shared_ptr<LimitsHandleBase> Ptr ROS_DEPRECATED;
 };
-
+typedef boost::shared_ptr<LimitsHandleBase> LimitsHandleBaseSharedPtr;
 
 class ObjectVariables {
-    const boost::shared_ptr<ObjectStorage> storage_;
+    const ObjectStorageSharedPtr storage_;
     struct Getter {
         boost::shared_ptr<double> val_ptr;
         boost::function<bool(double&)> func;
@@ -49,7 +49,7 @@ public:
         typedef typename ObjectStorage::DataType<dt>::type type;
         return list.getters_.insert(std::make_pair(key, Getter(list.storage_->entry<type>(key)))).first->second;
     }
-    ObjectVariables(const boost::shared_ptr<ObjectStorage> storage) : storage_(storage) {}
+    ObjectVariables(const ObjectStorageSharedPtr storage) : storage_(storage) {}
     bool sync(){
         boost::mutex::scoped_lock lock(mutex_);
         bool ok = true;
@@ -82,7 +82,7 @@ template<> inline double* ObjectVariables::func<canopen::ObjectDict::DEFTYPE_DOM
 
 
 class HandleLayer: public canopen::HandleLayerBase {
-    boost::shared_ptr<canopen::MotorBase> motor_;
+    canopen::MotorBaseSharedPtr motor_;
     double pos_, vel_, eff_;
 
     double cmd_pos_, cmd_vel_, cmd_eff_;
@@ -122,10 +122,10 @@ class HandleLayer: public canopen::HandleLayerBase {
     }
 
     bool select(const canopen::MotorBase::OperationMode &m);
-    std::vector<LimitsHandleBase::Ptr> limits_;
+    std::vector<LimitsHandleBaseSharedPtr> limits_;
     bool enable_limits_;
 public:
-    HandleLayer(const std::string &name, const boost::shared_ptr<canopen::MotorBase> & motor, const boost::shared_ptr<canopen::ObjectStorage> storage,  XmlRpc::XmlRpcValue & options);
+    HandleLayer(const std::string &name, const canopen::MotorBaseSharedPtr & motor, const canopen::ObjectStorageSharedPtr storage,  XmlRpc::XmlRpcValue & options);
     static double * assignVariable(const std::string &name, double * ptr, const std::string &req) { return name == req ? ptr : 0; }
 
     CanSwitchResult canSwitch(const canopen::MotorBase::OperationMode &m);

--- a/canopen_motor_node/include/canopen_motor_node/handle_layer_base.h
+++ b/canopen_motor_node/include/canopen_motor_node/handle_layer_base.h
@@ -37,6 +37,7 @@ public:
     virtual void enforceLimits(const ros::Duration &period, bool reset) = 0;
     virtual void enableLimits(bool enable) = 0;
 };
+typedef boost::shared_ptr<HandleLayerBase> HandleLayerBaseSharedPtr;
 
 }  // namespace canopen
 

--- a/canopen_motor_node/include/canopen_motor_node/motor_chain.h
+++ b/canopen_motor_node/include/canopen_motor_node/motor_chain.h
@@ -15,11 +15,11 @@ namespace canopen {
 class MotorChain : public canopen::RosChain {
     ClassAllocator<canopen::MotorBase> motor_allocator_;
     boost::shared_ptr< canopen::LayerGroupNoDiag<canopen::MotorBase> > motors_;
-    boost::shared_ptr<RobotLayer> robot_layer_;
+    RobotLayerSharedPtr robot_layer_;
 
     boost::shared_ptr<ControllerManagerLayer> cm_;
 
-    virtual bool nodeAdded(XmlRpc::XmlRpcValue &params, const boost::shared_ptr<Node> &node, const boost::shared_ptr<Logger> &logger);
+    virtual bool nodeAdded(XmlRpc::XmlRpcValue &params, const canopen::NodeSharedPtr &node, const LoggerSharedPtr &logger);
 
 public:
     MotorChain(const ros::NodeHandle &nh, const ros::NodeHandle &nh_priv);

--- a/canopen_motor_node/include/canopen_motor_node/robot_layer.h
+++ b/canopen_motor_node/include/canopen_motor_node/robot_layer.h
@@ -31,10 +31,10 @@ class RobotLayer : public LayerGroupNoDiag<HandleLayerBase>, public hardware_int
     ros::NodeHandle nh_;
     urdf::Model urdf_;
 
-    typedef boost::unordered_map< std::string, boost::shared_ptr<HandleLayerBase> > HandleMap;
+    typedef boost::unordered_map< std::string, HandleLayerBaseSharedPtr > HandleMap;
     HandleMap handles_;
     struct SwitchData {
-        boost::shared_ptr<HandleLayerBase> handle;
+        HandleLayerBaseSharedPtr handle;
         canopen::MotorBase::OperationMode mode;
         bool enforce_limits;
     };
@@ -46,7 +46,7 @@ class RobotLayer : public LayerGroupNoDiag<HandleLayerBase>, public hardware_int
 
     void stopControllers(const std::vector<std::string> controllers);
 public:
-    void add(const std::string &name, boost::shared_ptr<HandleLayerBase> handle);
+    void add(const std::string &name, HandleLayerBaseSharedPtr handle);
     RobotLayer(ros::NodeHandle nh);
     urdf::JointConstSharedPtr getJoint(const std::string &n) const { return urdf_.getJoint(n); }
 
@@ -55,6 +55,8 @@ public:
     virtual bool prepareSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list);
     virtual void doSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list);
 };
+
+typedef boost::shared_ptr<RobotLayer> RobotLayerSharedPtr;
 
 }  // namespace canopen
 

--- a/canopen_motor_node/include/canopen_motor_node/unit_converter.h
+++ b/canopen_motor_node/include/canopen_motor_node/unit_converter.h
@@ -12,9 +12,10 @@
 namespace canopen {
 class UnitConverter{
 public:
-    typedef boost::function<double * (const std::string &) > get_var_func_type;
+    typedef boost::function<double * (const std::string &) > get_var_func_type __attribute__((deprecated));
+    typedef boost::function<double * (const std::string &) > GetVarFuncType;
 
-    UnitConverter(const std::string &expression, get_var_func_type var_func)
+    UnitConverter(const std::string &expression, GetVarFuncType var_func)
     : var_func_(var_func)
     {
         parser_.SetVarFactory(UnitConverter::createVariable, this);
@@ -51,7 +52,7 @@ private:
         return p;
     }
     variable_ptr_list var_list_;
-    get_var_func_type var_func_;
+    GetVarFuncType var_func_;
 
     mu::Parser parser_;
 

--- a/canopen_motor_node/src/handle_layer.cpp
+++ b/canopen_motor_node/src/handle_layer.cpp
@@ -23,7 +23,7 @@ bool HandleLayer::select(const MotorBase::OperationMode &m){
     return true;
 }
 
-HandleLayer::HandleLayer(const std::string &name, const boost::shared_ptr<MotorBase> & motor, const boost::shared_ptr<ObjectStorage> storage,  XmlRpc::XmlRpcValue & options)
+HandleLayer::HandleLayer(const std::string &name, const MotorBaseSharedPtr & motor, const ObjectStorageSharedPtr storage,  XmlRpc::XmlRpcValue & options)
 : HandleLayerBase(name + " Handle"), motor_(motor), variables_(storage), jsh_(name, &pos_, &vel_, &eff_), jph_(jsh_, &cmd_pos_), jvh_(jsh_, &cmd_vel_), jeh_(jsh_, &cmd_eff_), jh_(0), forward_command_(false),
   filter_pos_("double"), filter_vel_("double"), filter_eff_("double"), options_(options), enable_limits_(true)
 {
@@ -91,8 +91,8 @@ bool HandleLayer::forwardForMode(const MotorBase::OperationMode &m){
 }
 
 
-template<typename T> void addLimitsHandle(std::vector<LimitsHandleBase::Ptr> &limits, const T &t) {
-    limits.push_back(LimitsHandleBase::Ptr( (LimitsHandleBase *) new LimitsHandle<T> (t) ));
+template<typename T> void addLimitsHandle(std::vector<LimitsHandleBaseSharedPtr> &limits, const T &t) {
+    limits.push_back(LimitsHandleBaseSharedPtr( (LimitsHandleBase *) new LimitsHandle<T> (t) ));
 }
 
 hardware_interface::JointHandle* HandleLayer::registerHandle(hardware_interface::PositionJointInterface &iface,
@@ -203,7 +203,7 @@ void HandleLayer::handleInit(LayerStatus &status){
 }
 
 void HandleLayer::enforceLimits(const ros::Duration &period, bool reset){
-    for(std::vector<LimitsHandleBase::Ptr>::iterator it = limits_.begin(); it != limits_.end(); ++it){
+    for(std::vector<LimitsHandleBaseSharedPtr>::iterator it = limits_.begin(); it != limits_.end(); ++it){
         if(reset) (*it)->reset();
         if(enable_limits_) (*it)->enforce(period);
     }

--- a/canopen_motor_node/src/motor_chain.cpp
+++ b/canopen_motor_node/src/motor_chain.cpp
@@ -28,7 +28,7 @@ private:
 MotorChain::MotorChain(const ros::NodeHandle &nh, const ros::NodeHandle &nh_priv) :
         RosChain(nh, nh_priv), motor_allocator_("canopen_402", "canopen::MotorBase::Allocator") {}
 
-bool MotorChain::nodeAdded(XmlRpc::XmlRpcValue &params, const boost::shared_ptr<canopen::Node> &node, const boost::shared_ptr<Logger> &logger)
+bool MotorChain::nodeAdded(XmlRpc::XmlRpcValue &params, const canopen::NodeSharedPtr &node, const LoggerSharedPtr &logger)
 {
     std::string name = params["name"];
     std::string &joint = name;
@@ -45,7 +45,7 @@ bool MotorChain::nodeAdded(XmlRpc::XmlRpcValue &params, const boost::shared_ptr<
     XmlRpcSettings settings;
     if(params.hasMember("motor_layer")) settings = params["motor_layer"];
 
-    boost::shared_ptr<MotorBase> motor;
+    MotorBaseSharedPtr motor;
 
     try{
         motor = motor_allocator_.allocateInstance(alloc_name, name + "_motor", node->getStorage(), settings);

--- a/canopen_motor_node/src/robot_layer.cpp
+++ b/canopen_motor_node/src/robot_layer.cpp
@@ -23,7 +23,7 @@ void RobotLayer::stopControllers(const std::vector<std::string> controllers){
     call.detach();
 }
 
-void RobotLayer::add(const std::string &name, boost::shared_ptr<HandleLayerBase> handle){
+void RobotLayer::add(const std::string &name, HandleLayerBaseSharedPtr handle){
     LayerGroupNoDiag::add(handle);
     handles_.insert(std::make_pair(name, handle));
 }
@@ -137,7 +137,7 @@ bool RobotLayer::prepareSwitch(const std::list<hardware_interface::ControllerInf
                         return false;
                     }
 
-                    boost::unordered_map< std::string, boost::shared_ptr<HandleLayerBase> >::const_iterator h_it = handles_.find(*res_it);
+                    boost::unordered_map< std::string, HandleLayerBaseSharedPtr >::const_iterator h_it = handles_.find(*res_it);
 
                     const std::string & joint = *res_it;
 
@@ -179,7 +179,7 @@ bool RobotLayer::prepareSwitch(const std::list<hardware_interface::ControllerInf
     }
 
     // perform mode switches
-    boost::unordered_set<boost::shared_ptr<HandleLayerBase> > to_stop;
+    boost::unordered_set<HandleLayerBaseSharedPtr > to_stop;
     std::vector<std::string> failed_controllers;
     for (std::list<hardware_interface::ControllerInfo>::const_iterator controller_it = stop_list.begin(); controller_it != stop_list.end(); ++controller_it){
         SwitchContainer &to_switch = switch_map_.at(controller_it->name);
@@ -208,7 +208,7 @@ bool RobotLayer::prepareSwitch(const std::list<hardware_interface::ControllerInf
             to_stop.erase(it->handle);
         }
     }
-    for(boost::unordered_set<boost::shared_ptr<HandleLayerBase> >::iterator it = to_stop.begin(); it != to_stop.end(); ++it){
+    for(boost::unordered_set<HandleLayerBaseSharedPtr >::iterator it = to_stop.begin(); it != to_stop.end(); ++it){
         (*it)->switchMode(MotorBase::No_Mode);
     }
     if(!failed_controllers.empty()){

--- a/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
+++ b/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
@@ -38,7 +38,7 @@ namespace socketcan_bridge
 class SocketCANToTopic
 {
   public:
-    SocketCANToTopic(ros::NodeHandle* nh, ros::NodeHandle* nh_param, boost::shared_ptr<can::DriverInterface> driver);
+    SocketCANToTopic(ros::NodeHandle* nh, ros::NodeHandle* nh_param, can::DriverInterfaceSharedPtr driver);
     void setup();
     void setup(const can::FilteredFrameListener::FilterVector &filters);
     void setup(XmlRpc::XmlRpcValue filters);
@@ -46,10 +46,10 @@ class SocketCANToTopic
 
   private:
     ros::Publisher can_topic_;
-    boost::shared_ptr<can::DriverInterface> driver_;
+    can::DriverInterfaceSharedPtr driver_;
 
-    can::CommInterface::FrameListener::Ptr frame_listener_;
-    can::StateInterface::StateListener::Ptr state_listener_;
+    can::FrameListenerConstSharedPtr frame_listener_;
+    can::StateListenerConstSharedPtr state_listener_;
 
 
     void frameCallback(const can::Frame& f);

--- a/socketcan_bridge/include/socketcan_bridge/topic_to_socketcan.h
+++ b/socketcan_bridge/include/socketcan_bridge/topic_to_socketcan.h
@@ -37,14 +37,14 @@ namespace socketcan_bridge
 class TopicToSocketCAN
 {
   public:
-    TopicToSocketCAN(ros::NodeHandle* nh, ros::NodeHandle* nh_param, boost::shared_ptr<can::DriverInterface> driver);
+    TopicToSocketCAN(ros::NodeHandle* nh, ros::NodeHandle* nh_param, can::DriverInterfaceSharedPtr driver);
     void setup();
 
   private:
     ros::Subscriber can_topic_;
-    boost::shared_ptr<can::DriverInterface> driver_;
+    can::DriverInterfaceSharedPtr driver_;
 
-    can::StateInterface::StateListener::Ptr state_listener_;
+    can::StateListenerConstSharedPtr state_listener_;
 
     void msgCallback(const can_msgs::Frame::ConstPtr& msg);
     void stateCallback(const can::State & s);

--- a/socketcan_bridge/src/socketcan_bridge_node.cpp
+++ b/socketcan_bridge/src/socketcan_bridge_node.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   std::string can_device;
   nh_param.param<std::string>("can_device", can_device, "can0");
 
-  can::ThreadedSocketCANInterfaceSharedPtr driver = boost::make_shared<can::ThreadedSocketCANInterface> ();
+  can::ThreadedSocketCANInterfaceSharedPtr driver = can::make_shared<can::ThreadedSocketCANInterface> ();
 
   if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {

--- a/socketcan_bridge/src/socketcan_bridge_node.cpp
+++ b/socketcan_bridge/src/socketcan_bridge_node.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   std::string can_device;
   nh_param.param<std::string>("can_device", can_device, "can0");
 
-  boost::shared_ptr<can::ThreadedSocketCANInterface> driver = boost::make_shared<can::ThreadedSocketCANInterface> ();
+  can::ThreadedSocketCANInterfaceSharedPtr driver = boost::make_shared<can::ThreadedSocketCANInterface> ();
 
   if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {

--- a/socketcan_bridge/src/socketcan_to_topic.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic.cpp
@@ -31,7 +31,7 @@
 #include <string>
 
 namespace can {
-template<> can::FrameFilter::Ptr tofilter(const XmlRpc::XmlRpcValue  &ct) {
+template<> can::FrameFilterSharedPtr tofilter(const XmlRpc::XmlRpcValue  &ct) {
   XmlRpc::XmlRpcValue t(ct);
   try{ // to read as integer
       uint32_t id = static_cast<int>(t);
@@ -46,7 +46,7 @@ template<> can::FrameFilter::Ptr tofilter(const XmlRpc::XmlRpcValue  &ct) {
 namespace socketcan_bridge
 {
   SocketCANToTopic::SocketCANToTopic(ros::NodeHandle* nh, ros::NodeHandle* nh_param,
-      boost::shared_ptr<can::DriverInterface> driver)
+      can::DriverInterfaceSharedPtr driver)
     {
       can_topic_ = nh->advertise<can_msgs::Frame>("received_messages", 10);
       driver_ = driver;

--- a/socketcan_bridge/src/socketcan_to_topic_node.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic_node.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   std::string can_device;
   nh_param.param<std::string>("can_device", can_device, "can0");
 
-  can::ThreadedSocketCANInterfaceSharedPtr driver = boost::make_shared<can::ThreadedSocketCANInterface> ();
+  can::ThreadedSocketCANInterfaceSharedPtr driver = can::make_shared<can::ThreadedSocketCANInterface> ();
 
   if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {

--- a/socketcan_bridge/src/socketcan_to_topic_node.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic_node.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   std::string can_device;
   nh_param.param<std::string>("can_device", can_device, "can0");
 
-  boost::shared_ptr<can::ThreadedSocketCANInterface> driver = boost::make_shared<can::ThreadedSocketCANInterface> ();
+  can::ThreadedSocketCANInterfaceSharedPtr driver = boost::make_shared<can::ThreadedSocketCANInterface> ();
 
   if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {

--- a/socketcan_bridge/src/topic_to_socketcan.cpp
+++ b/socketcan_bridge/src/topic_to_socketcan.cpp
@@ -32,7 +32,7 @@
 namespace socketcan_bridge
 {
   TopicToSocketCAN::TopicToSocketCAN(ros::NodeHandle* nh, ros::NodeHandle* nh_param,
-      boost::shared_ptr<can::DriverInterface> driver)
+      can::DriverInterfaceSharedPtr driver)
     {
       can_topic_ = nh->subscribe<can_msgs::Frame>("sent_messages", 10,
                     boost::bind(&TopicToSocketCAN::msgCallback, this, _1));

--- a/socketcan_bridge/src/topic_to_socketcan_node.cpp
+++ b/socketcan_bridge/src/topic_to_socketcan_node.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   std::string can_device;
   nh_param.param<std::string>("can_device", can_device, "can0");
 
-  can::ThreadedSocketCANInterfaceSharedPtr driver = boost::make_shared<can::ThreadedSocketCANInterface> ();
+  can::ThreadedSocketCANInterfaceSharedPtr driver = can::make_shared<can::ThreadedSocketCANInterface> ();
 
   if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {

--- a/socketcan_bridge/src/topic_to_socketcan_node.cpp
+++ b/socketcan_bridge/src/topic_to_socketcan_node.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   std::string can_device;
   nh_param.param<std::string>("can_device", can_device, "can0");
 
-  boost::shared_ptr<can::ThreadedSocketCANInterface> driver = boost::make_shared<can::ThreadedSocketCANInterface> ();
+  can::ThreadedSocketCANInterfaceSharedPtr driver = boost::make_shared<can::ThreadedSocketCANInterface> ();
 
   if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
   {

--- a/socketcan_bridge/test/to_socketcan_test.cpp
+++ b/socketcan_bridge/test/to_socketcan_test.cpp
@@ -52,7 +52,7 @@ TEST(TopicToSocketCANTest, checkCorrectData)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  boost::shared_ptr<can::DummyInterface> driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
 
   // start the to topic bridge.
   socketcan_bridge::TopicToSocketCAN to_socketcan_bridge(&nh, &nh_param, driver_);
@@ -68,7 +68,7 @@ TEST(TopicToSocketCANTest, checkCorrectData)
   frameCollector frame_collector_;
 
   //  driver->createMsgListener(&frameCallback);
-  can::CommInterface::FrameListener::Ptr frame_listener_ = driver_->createMsgListener(
+  can::FrameListenerConstSharedPtr frame_listener_ = driver_->createMsgListener(
             can::CommInterface::FrameDelegate(&frame_collector_, &frameCollector::frameCallback));
 
   // create a message
@@ -114,7 +114,7 @@ TEST(TopicToSocketCANTest, checkInvalidFrameHandling)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  boost::shared_ptr<can::DummyInterface> driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
 
   // start the to topic bridge.
   socketcan_bridge::TopicToSocketCAN to_socketcan_bridge(&nh, &nh_param, driver_);
@@ -127,7 +127,7 @@ TEST(TopicToSocketCANTest, checkInvalidFrameHandling)
   frameCollector frame_collector_;
 
   //  add callback to the dummy interface.
-  can::CommInterface::FrameListener::Ptr frame_listener_ = driver_->createMsgListener(
+  can::FrameListenerConstSharedPtr frame_listener_ = driver_->createMsgListener(
           can::CommInterface::FrameDelegate(&frame_collector_, &frameCollector::frameCallback));
 
   // create a message

--- a/socketcan_bridge/test/to_socketcan_test.cpp
+++ b/socketcan_bridge/test/to_socketcan_test.cpp
@@ -52,7 +52,7 @@ TEST(TopicToSocketCANTest, checkCorrectData)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = can::make_shared<can::DummyInterface>(true);
 
   // start the to topic bridge.
   socketcan_bridge::TopicToSocketCAN to_socketcan_bridge(&nh, &nh_param, driver_);
@@ -114,7 +114,7 @@ TEST(TopicToSocketCANTest, checkInvalidFrameHandling)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = can::make_shared<can::DummyInterface>(true);
 
   // start the to topic bridge.
   socketcan_bridge::TopicToSocketCAN to_socketcan_bridge(&nh, &nh_param, driver_);

--- a/socketcan_bridge/test/to_topic_test.cpp
+++ b/socketcan_bridge/test/to_topic_test.cpp
@@ -59,7 +59,7 @@ TEST(SocketCANToTopicTest, checkCorrectData)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = can::make_shared<can::DummyInterface>(true);
 
   // start the to topic bridge.
   socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver_);
@@ -118,7 +118,7 @@ TEST(SocketCANToTopicTest, checkInvalidFrameHandling)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = can::make_shared<can::DummyInterface>(true);
 
   // start the to topic bridge.
   socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver_);
@@ -157,7 +157,7 @@ TEST(SocketCANToTopicTest, checkCorrectCanIdFilter)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = can::make_shared<can::DummyInterface>(true);
 
   //create can_id vector with id that should be passed and published to ros
   std::vector<unsigned int> pass_can_ids;
@@ -213,7 +213,7 @@ TEST(SocketCANToTopicTest, checkInvalidCanIdFilter)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = can::make_shared<can::DummyInterface>(true);
 
   //create can_id vector with id that should not be received on can bus
   std::vector<unsigned int> pass_can_ids;
@@ -259,7 +259,7 @@ TEST(SocketCANToTopicTest, checkMaskFilter)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = can::make_shared<can::DummyInterface>(true);
 
   // setup filter
   can::FilteredFrameListener::FilterVector filters;

--- a/socketcan_bridge/test/to_topic_test.cpp
+++ b/socketcan_bridge/test/to_topic_test.cpp
@@ -59,7 +59,7 @@ TEST(SocketCANToTopicTest, checkCorrectData)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  boost::shared_ptr<can::DummyInterface> driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
 
   // start the to topic bridge.
   socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver_);
@@ -118,7 +118,7 @@ TEST(SocketCANToTopicTest, checkInvalidFrameHandling)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  boost::shared_ptr<can::DummyInterface> driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
 
   // start the to topic bridge.
   socketcan_bridge::SocketCANToTopic to_topic_bridge(&nh, &nh_param, driver_);
@@ -157,7 +157,7 @@ TEST(SocketCANToTopicTest, checkCorrectCanIdFilter)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  boost::shared_ptr<can::DummyInterface> driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
 
   //create can_id vector with id that should be passed and published to ros
   std::vector<unsigned int> pass_can_ids;
@@ -213,7 +213,7 @@ TEST(SocketCANToTopicTest, checkInvalidCanIdFilter)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  boost::shared_ptr<can::DummyInterface> driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
 
   //create can_id vector with id that should not be received on can bus
   std::vector<unsigned int> pass_can_ids;
@@ -259,7 +259,7 @@ TEST(SocketCANToTopicTest, checkMaskFilter)
   ros::NodeHandle nh(""), nh_param("~");
 
   // create the dummy interface
-  boost::shared_ptr<can::DummyInterface> driver_ = boost::make_shared<can::DummyInterface>(true);
+  can::DummyInterfaceSharedPtr driver_ = boost::make_shared<can::DummyInterface>(true);
 
   // setup filter
   can::FilteredFrameListener::FilterVector filters;

--- a/socketcan_interface/include/socketcan_interface/asio_base.h
+++ b/socketcan_interface/include/socketcan_interface/asio_base.h
@@ -16,11 +16,11 @@ template<typename Socket> class AsioDriver : public DriverInterface{
     typedef SimpleDispatcher<StateInterface::StateListener> StateDispatcher;
     FrameDispatcher frame_dispatcher_;
     StateDispatcher state_dispatcher_;
-  
+
     State state_;
     boost::mutex state_mutex_;
     boost::mutex socket_mutex_;
-    
+
 protected:
     boost::asio::io_service io_service_;
 #if BOOST_ASIO_VERSION >= 101200 // Boost 1.66+
@@ -30,10 +30,10 @@ protected:
 #endif
     Socket socket_;
     Frame input_;
-    
+
     virtual void triggerReadSome() = 0;
     virtual bool enqueue(const Frame & msg) = 0;
-    
+
     void dispatchFrame(const Frame &msg){
         strand_.post(boost::bind(&FrameDispatcher::dispatch, &frame_dispatcher_, msg)); // copies msg
     }
@@ -62,7 +62,7 @@ protected:
     void setNotReady(){
         setDriverState(socket_.is_open()?State::open : State::closed);
     }
-    
+
     void frameReceived(const boost::system::error_code& error){
         if(!error){
             dispatchFrame(input_);
@@ -79,35 +79,35 @@ protected:
 
 public:
     virtual ~AsioDriver() { shutdown(); }
-    
+
     State getState(){
         boost::mutex::scoped_lock lock(state_mutex_);
         return state_;
     }
     virtual void run(){
         setNotReady();
-        
+
         if(getState().driver_state == State::open){
             io_service_.reset();
             boost::asio::io_service::work work(io_service_);
             setDriverState(State::ready);
 
             boost::thread post_thread(boost::bind(&boost::asio::io_service::run, &io_service_));
-            
+
             triggerReadSome();
-            
+
             boost::system::error_code ec;
             io_service_.run(ec);
             setErrorCode(ec);
-            
+
             setNotReady();
-        }   
+        }
         state_dispatcher_.dispatch(getState());
     }
     virtual bool send(const Frame & msg){
         return getState().driver_state == State::ready && enqueue(msg);
     }
-    
+
     virtual void shutdown(){
         if(socket_.is_open()){
             socket_.cancel();
@@ -115,14 +115,14 @@ public:
         }
         io_service_.stop();
     }
-    
-    virtual FrameListener::Ptr createMsgListener(const FrameDelegate &delegate){
+
+    virtual FrameListenerConstSharedPtr createMsgListener(const FrameDelegate &delegate){
         return frame_dispatcher_.createListener(delegate);
     }
-    virtual FrameListener::Ptr createMsgListener(const Frame::Header&h , const FrameDelegate &delegate){
+    virtual FrameListenerConstSharedPtr createMsgListener(const Frame::Header&h , const FrameDelegate &delegate){
         return frame_dispatcher_.createListener(h, delegate);
     }
-    virtual StateListener::Ptr createStateListener(const StateDelegate &delegate){
+    virtual StateListenerConstSharedPtr createStateListener(const StateDelegate &delegate){
         return state_dispatcher_.createListener(delegate);
     }
 

--- a/socketcan_interface/include/socketcan_interface/dispatcher.h
+++ b/socketcan_interface/include/socketcan_interface/dispatcher.h
@@ -15,26 +15,29 @@ template< typename Listener > class SimpleDispatcher{
 public:
     typedef typename Listener::Callable Callable;
     typedef typename Listener::Type Type;
+    typedef typename Listener::ListenerConstSharedPtr ListenerConstSharedPtr;
 protected:
+    class DispatcherBase;
+    typedef boost::shared_ptr<DispatcherBase> DispatcherBaseSharedPtr;
     class DispatcherBase : boost::noncopyable{
         class GuardedListener: public Listener{
             boost::weak_ptr<DispatcherBase> guard_;
         public:
-            GuardedListener(boost::shared_ptr<DispatcherBase> g, const Callable &callable): Listener(callable), guard_(g){}
+            GuardedListener(DispatcherBaseSharedPtr g, const Callable &callable): Listener(callable), guard_(g){}
             virtual ~GuardedListener() {
-                boost::shared_ptr<DispatcherBase> d = guard_.lock();
+                DispatcherBaseSharedPtr d = guard_.lock();
                 if(d){
                     d->remove(this);
                 }
             }
         };
-        
+
         boost::mutex &mutex_;
-        std::list< Listener* > listeners_;
+        std::list<const Listener* > listeners_;
     public:
         DispatcherBase(boost::mutex &mutex) : mutex_(mutex) {}
         void dispatch_nolock(const Type &obj) const{
-           for(typename std::list<Listener* >::const_iterator it=listeners_.begin(); it != listeners_.end(); ++it){
+           for(typename std::list<const Listener* >::const_iterator it=listeners_.begin(); it != listeners_.end(); ++it){
                (**it)(obj);
             }
         }
@@ -47,17 +50,17 @@ protected:
             return listeners_.size();
         }
 
-        static typename Listener::Ptr createListener(boost::shared_ptr<DispatcherBase> dispatcher, const  Callable &callable){
-            boost::shared_ptr<Listener > l(new GuardedListener(dispatcher,callable));
+        static ListenerConstSharedPtr createListener(DispatcherBaseSharedPtr dispatcher, const  Callable &callable){
+            ListenerConstSharedPtr l(new GuardedListener(dispatcher,callable));
             dispatcher->listeners_.push_back(l.get());
             return l;
         }
     };
     boost::mutex mutex_;
-    boost::shared_ptr<DispatcherBase> dispatcher_;
+    DispatcherBaseSharedPtr dispatcher_;
 public:
     SimpleDispatcher() : dispatcher_(new DispatcherBase(mutex_)) {}
-    typename Listener::Ptr createListener(const Callable &callable){
+    ListenerConstSharedPtr createListener(const Callable &callable){
         boost::mutex::scoped_lock lock(mutex_);
         return DispatcherBase::createListener(dispatcher_, callable);
     }
@@ -73,18 +76,18 @@ public:
 
 template<typename K, typename Listener, typename Hash = boost::hash<K> > class FilteredDispatcher: public SimpleDispatcher<Listener>{
     typedef SimpleDispatcher<Listener> BaseClass;
-    boost::unordered_map<K, boost::shared_ptr<typename BaseClass::DispatcherBase >, Hash> filtered_;
+    boost::unordered_map<K, typename BaseClass::DispatcherBaseSharedPtr, Hash> filtered_;
 public:
     using BaseClass::createListener;
-    typename Listener::Ptr createListener(const K &key, const typename BaseClass::Callable &callable){
+    typename BaseClass::ListenerConstSharedPtr createListener(const K &key, const typename BaseClass::Callable &callable){
         boost::mutex::scoped_lock lock(BaseClass::mutex_);
-        boost::shared_ptr<typename BaseClass::DispatcherBase > &ptr = filtered_[key];
+        typename BaseClass::DispatcherBaseSharedPtr &ptr = filtered_[key];
         if(!ptr) ptr.reset(new typename BaseClass::DispatcherBase(BaseClass::mutex_));
         return BaseClass::DispatcherBase::createListener(ptr, callable);
     }
     void dispatch(const typename BaseClass::Type &obj){
         boost::mutex::scoped_lock lock(BaseClass::mutex_);
-        boost::shared_ptr<typename BaseClass::DispatcherBase > &ptr = filtered_[obj];
+        typename BaseClass::DispatcherBaseSharedPtr &ptr = filtered_[obj];
         if(ptr) ptr->dispatch_nolock(obj);
         BaseClass::dispatcher_->dispatch_nolock(obj);
     }

--- a/socketcan_interface/include/socketcan_interface/dummy.h
+++ b/socketcan_interface/include/socketcan_interface/dummy.h
@@ -53,10 +53,10 @@ public:
         return true;
     }
 
-    virtual FrameListener::Ptr createMsgListener(const FrameDelegate &delegate){
+    virtual FrameListenerConstSharedPtr createMsgListener(const FrameDelegate &delegate){
         return frame_dispatcher_.createListener(delegate);
     }
-    virtual FrameListener::Ptr createMsgListener(const Frame::Header&h , const FrameDelegate &delegate){
+    virtual FrameListenerConstSharedPtr createMsgListener(const Frame::Header&h , const FrameDelegate &delegate){
         return frame_dispatcher_.createListener(h, delegate);
     }
 
@@ -87,11 +87,12 @@ public:
         return true;
     };
 
-    virtual StateListener::Ptr createStateListener(const StateDelegate &delegate){
+    virtual StateListenerConstSharedPtr createStateListener(const StateDelegate &delegate){
       return state_dispatcher_.createListener(delegate);
     };
 
 };
+typedef boost::shared_ptr<DummyInterface> DummyInterfaceSharedPtr;
 
 
 }

--- a/socketcan_interface/include/socketcan_interface/filter.h
+++ b/socketcan_interface/include/socketcan_interface/filter.h
@@ -9,10 +9,10 @@ namespace can {
 
 class FrameFilter {
 public:
-  typedef boost::shared_ptr<FrameFilter> Ptr;
   virtual bool pass(const can::Frame &frame) const = 0;
   virtual ~FrameFilter() {}
 };
+typedef boost::shared_ptr<FrameFilter> FrameFilterSharedPtr;
 
 class FrameMaskFilter : public FrameFilter {
 public:
@@ -46,8 +46,8 @@ private:
 
 class FilteredFrameListener : public CommInterface::FrameListener {
 public:
-  typedef std::vector<FrameFilter::Ptr> FilterVector;
-  FilteredFrameListener(boost::shared_ptr<CommInterface> comm, const Callable &callable, const FilterVector &filters)
+  typedef std::vector<FrameFilterSharedPtr> FilterVector;
+  FilteredFrameListener(CommInterfaceSharedPtr comm, const Callable &callable, const FilterVector &filters)
   : CommInterface::FrameListener(callable),
     filters_(filters),
     listener_(comm->createMsgListener(Callable(this, &FilteredFrameListener::filter)))
@@ -61,8 +61,8 @@ private:
       }
     }
   }
-  const std::vector<FrameFilter::Ptr> filters_;
-  CommInterface::FrameListener::Ptr listener_;
+  const std::vector<FrameFilterSharedPtr> filters_;
+  CommInterface::FrameListenerConstSharedPtr listener_;
 };
 
 } // namespace can

--- a/socketcan_interface/include/socketcan_interface/interface.h
+++ b/socketcan_interface/include/socketcan_interface/interface.h
@@ -4,6 +4,7 @@
 #include <boost/array.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
 
 #include "FastDelegate.h"
 
@@ -126,8 +127,8 @@ public:
     typedef FrameListener::ListenerConstSharedPtr FrameListenerConstSharedPtr;
 
     /**
+    *
      * enqueue frame for sending
-     *
      * @param[in] msg: message to be enqueued
      * @return true if frame was enqueued succesfully, otherwise false
      */
@@ -196,6 +197,7 @@ public:
 };
 typedef boost::shared_ptr<DriverInterface> DriverInterfaceSharedPtr;
 
+using boost::make_shared;
 
 } // namespace can
 

--- a/socketcan_interface/include/socketcan_interface/interface.h
+++ b/socketcan_interface/include/socketcan_interface/interface.h
@@ -15,11 +15,11 @@ struct Header{
     static const unsigned int ERROR_MASK = (1u << 29);
     static const unsigned int RTR_MASK = (1u << 30);
     static const unsigned int EXTENDED_MASK = (1u << 31);
-    
+
     unsigned int id:29; ///< CAN ID (11 or 29 bits valid, depending on is_extended member
     unsigned int is_error:1; ///< marks an error frame (only used internally)
     unsigned int is_rtr:1; ///< frame is a remote transfer request
-    unsigned int is_extended:1; ///< frame uses 29 bit CAN identifier 
+    unsigned int is_extended:1; ///< frame uses 29 bit CAN identifier
     /** check if frame header is valid*/
     bool isValid() const{
         return id < (is_extended?(1<<29):(1<<11));
@@ -29,12 +29,12 @@ struct Header{
         * @param[in] extended: uses 29 bit identifier, defaults to false
         * @param[in] rtr: is rtr frame, defaults to false
         */
-    
+
     operator const unsigned int() const { return is_error ? (ERROR_MASK) : *(unsigned int*) this; }
 
     Header()
     : id(0),is_error(0),is_rtr(0), is_extended(0) {}
-    
+
     Header(unsigned int i, bool extended, bool rtr, bool error)
     : id(i),is_error(error?1:0),is_rtr(rtr?1:0), is_extended(extended?1:0) {}
 };
@@ -50,18 +50,18 @@ struct ErrorHeader : public Header{
     ErrorHeader(unsigned int i=0) : Header(i, false, false, true) {}
 };
 
-    
-    
-/** reprentation of a CAN frame */   
+
+
+/** representation of a CAN frame */
 struct Frame: public Header{
     boost::array<unsigned char, 8> data; ///< array for 8 data bytes with bounds checking
     unsigned char dlc; ///< len of data
-    
+
     /** check if frame header and length are valid*/
     bool isValid() const{
         return (dlc <= 8)  &&  Header::isValid();
     }
-    /** 
+    /**
      * constructor with default parameters
      * @param[in] i: CAN id, defaults to 0
      * @param[in] l: number of data bytes, defaults to 0
@@ -79,8 +79,8 @@ public:
         closed, open, ready
     } driver_state;
     boost::system::error_code error_code; ///< device access error
-    unsigned int internal_error; ///< driver specific error 
-    
+    unsigned int internal_error; ///< driver specific error
+
     State() : driver_state(closed), internal_error(0) {}
     virtual bool isReady() const { return driver_state == ready; }
     virtual ~State() {}
@@ -92,76 +92,84 @@ template <typename T,typename U> class Listener{
 public:
     typedef U Type;
     typedef T Callable;
-    typedef boost::shared_ptr<const Listener> Ptr;
-    
+    typedef boost::shared_ptr<const Listener> ListenerConstSharedPtr;
+    typedef ListenerConstSharedPtr Ptr __attribute__((deprecated));
+
     Listener(const T &callable):callable_(callable){ }
     void operator()(const U & u) const { if(callable_) callable_(u); }
-    virtual ~Listener() {} 
+    virtual ~Listener() {}
 };
 
 class StateInterface{
 public:
     typedef fastdelegate::FastDelegate1<const State&> StateDelegate;
     typedef Listener<const StateDelegate, const State&> StateListener;
+    typedef StateListener::ListenerConstSharedPtr StateListenerConstSharedPtr;
 
     /**
      * acquire a listener for the specified delegate, that will get called for all state changes
-     * 
+     *
      * @param[in] delegate: delegate to be bound by the listener
      * @return managed pointer to listener
      */
-    virtual StateListener::Ptr createStateListener(const StateDelegate &delegate) = 0;
+    virtual StateListenerConstSharedPtr createStateListener(const StateDelegate &delegate) = 0;
 
     virtual ~StateInterface() {}
 };
+typedef boost::shared_ptr<StateInterface> StateInterfaceSharedPtr;
+typedef StateInterface::StateListenerConstSharedPtr StateListenerConstSharedPtr;
 
 class CommInterface{
 public:
     typedef fastdelegate::FastDelegate1<const Frame&> FrameDelegate;
     typedef Listener<const FrameDelegate, const Frame&> FrameListener;
+    typedef FrameListener::ListenerConstSharedPtr FrameListenerConstSharedPtr;
 
     /**
      * enqueue frame for sending
-     * 
+     *
      * @param[in] msg: message to be enqueued
      * @return true if frame was enqueued succesfully, otherwise false
      */
     virtual bool send(const Frame & msg) = 0;
-    
+
     /**
      * acquire a listener for the specified delegate, that will get called for all messages
-     * 
+     *
      * @param[in] delegate: delegate to be bound by the listener
      * @return managed pointer to listener
      */
-    virtual FrameListener::Ptr createMsgListener(const FrameDelegate &delegate) = 0;
-    
+    virtual FrameListenerConstSharedPtr createMsgListener(const FrameDelegate &delegate) = 0;
+
     /**
      * acquire a listener for the specified delegate, that will get called for messages with demanded ID
-     * 
+     *
      * @param[in] header: CAN header to restrict listener on
      * @param[in] delegate: delegate to be bound listener
      * @return managed pointer to listener
      */
-    virtual FrameListener::Ptr createMsgListener(const Frame::Header&, const FrameDelegate &delegate) = 0;
-    
+    virtual FrameListenerConstSharedPtr createMsgListener(const Frame::Header&, const FrameDelegate &delegate) = 0;
+
     virtual ~CommInterface() {}
 };
+typedef boost::shared_ptr<CommInterface> CommInterfaceSharedPtr;
+typedef CommInterface::FrameListenerConstSharedPtr FrameListenerConstSharedPtr;
+
 
 class DriverInterface : public CommInterface, public StateInterface {
 public:
     /**
      * initialize interface
-     * 
+     *
      * @param[in] device: driver-specific device name/path
      * @param[in] loopback: loop-back own messages
      * @return true if device was initialized succesfully, false otherwise
      */
     virtual bool init(const std::string &device, bool loopback) = 0;
-    
+
     /**
      * Recover interface after errors and emergency stops
-     * 
+     *
      * @return true if device was recovered succesfully, false otherwise
      */
     virtual bool recover() = 0;
@@ -177,15 +185,16 @@ public:
      * @return true if shutdown was succesful, false otherwise
      */
     virtual void shutdown() = 0;
-    
+
     virtual bool translateError(unsigned int internal_error, std::string & str) = 0;
-    
+
     virtual bool doesLoopBack() const = 0;
-    
+
     virtual void run()  = 0;
-    
+
     virtual ~DriverInterface() {}
 };
+typedef boost::shared_ptr<DriverInterface> DriverInterfaceSharedPtr;
 
 
 } // namespace can

--- a/socketcan_interface/include/socketcan_interface/reader.h
+++ b/socketcan_interface/include/socketcan_interface/reader.h
@@ -14,7 +14,7 @@ class BufferedReader {
     std::deque<can::Frame> buffer_;
     boost::mutex mutex_;
     boost::condition_variable cond_;
-    CommInterface::FrameListener::Ptr listener_;
+    CommInterface::FrameListenerConstSharedPtr listener_;
     bool enabled_;
     size_t max_len_;
 
@@ -77,12 +77,12 @@ public:
         enabled_ = false;
     }
 
-    void listen(boost::shared_ptr<CommInterface> interface){
+    void listen(CommInterfaceSharedPtr interface){
         boost::mutex::scoped_lock lock(mutex_);
         listener_ = interface->createMsgListener(CommInterface::FrameDelegate(this, &BufferedReader::handleFrame));
         buffer_.clear();
     }
-    void listen(boost::shared_ptr<CommInterface> interface, const Frame::Header& h){
+    void listen(CommInterfaceSharedPtr interface, const Frame::Header& h){
         boost::mutex::scoped_lock lock(mutex_);
         listener_ = interface->createMsgListener(h, CommInterface::FrameDelegate(this, &BufferedReader::handleFrame));
         buffer_.clear();

--- a/socketcan_interface/include/socketcan_interface/string.h
+++ b/socketcan_interface/include/socketcan_interface/string.h
@@ -26,11 +26,11 @@ std::string tostring(const Frame& f, bool lc);
 
 Frame toframe(const std::string& s);
 
-template<class T> FrameFilter::Ptr tofilter(const T  &ct);
-template<> FrameFilter::Ptr tofilter(const std::string &s);
-template<> FrameFilter::Ptr tofilter(const uint32_t &id);
+template<class T> FrameFilterSharedPtr tofilter(const T  &ct);
+template<> FrameFilterSharedPtr tofilter(const std::string &s);
+template<> FrameFilterSharedPtr tofilter(const uint32_t &id);
 
-FrameFilter::Ptr tofilter(const char* s);
+FrameFilterSharedPtr tofilter(const char* s);
 
 template <typename T> FilteredFrameListener::FilterVector tofilters(const T& v) {
     FilteredFrameListener::FilterVector filters;

--- a/socketcan_interface/include/socketcan_interface/threading.h
+++ b/socketcan_interface/include/socketcan_interface/threading.h
@@ -11,7 +11,7 @@ namespace can{
 class StateWaiter{
     boost::mutex mutex_;
     boost::condition_variable cond_;
-    can::StateInterface::StateListener::Ptr state_listener_;
+    can::StateInterface::StateListenerConstSharedPtr state_listener_;
     can::State state_;
     void updateState(const can::State &s){
         boost::mutex::scoped_lock lock(mutex_);

--- a/socketcan_interface/src/candump.cpp
+++ b/socketcan_interface/src/candump.cpp
@@ -12,7 +12,7 @@ using namespace can;
 void print_error(const State & s);
 
 void print_frame(const Frame &f){
-    
+
     if(f.is_error){
         std::cout << "E " << std::hex << f.id << std::dec;
     }else if(f.is_extended){
@@ -20,25 +20,25 @@ void print_frame(const Frame &f){
     }else{
         std::cout << "s " << std::hex << f.id << std::dec;
     }
-    
+
     std::cout << "\t";
-    
+
     if(f.is_rtr){
         std::cout << "r";
     }else{
         std::cout << (int) f.dlc << std::hex;
-        
+
         for(int i=0; i < f.dlc; ++i){
             std::cout << std::hex << " " << (int) f.data[i];
         }
     }
-    
+
     std::cout << std::dec << std::endl;
 }
 
 
 boost::shared_ptr<class_loader::ClassLoader> g_loader;
-boost::shared_ptr<DriverInterface> g_driver;
+DriverInterfaceSharedPtr g_driver;
 
 void print_error(const State & s){
     std::string err;
@@ -48,7 +48,7 @@ void print_error(const State & s){
 
 
 int main(int argc, char *argv[]){
-    
+
     if(argc != 2 && argc != 4){
         std::cout << "usage: "<< argv[0] << " DEVICE [PLUGIN_PATH PLUGIN_NAME]" << std::endl;
         return 1;
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]){
             g_loader = boost::make_shared<class_loader::ClassLoader>(argv[2]);
             g_driver = g_loader->createInstance<DriverInterface>(argv[3]);
         }
-        
+
         catch(std::exception& ex)
         {
             std::cerr << boost::diagnostic_information(ex) << std::endl;;
@@ -69,23 +69,23 @@ int main(int argc, char *argv[]){
     }else{
         g_driver = boost::make_shared<SocketCANInterface>();
     }
-    
 
 
-    CommInterface::FrameListener::Ptr frame_printer = g_driver->createMsgListener(print_frame);
-    StateInterface::StateListener::Ptr error_printer = g_driver->createStateListener(print_error);
-    
+
+    FrameListenerConstSharedPtr frame_printer = g_driver->createMsgListener(print_frame);
+    StateListenerConstSharedPtr error_printer = g_driver->createStateListener(print_error);
+
     if(!g_driver->init(argv[1], false)){
         print_error(g_driver->getState());
         return 1;
     }
 
     g_driver->run();
-    
+
     g_driver->shutdown();
     g_driver.reset();
     g_loader.reset();
-    
+
     return 0;
-    
+
 }

--- a/socketcan_interface/src/candump.cpp
+++ b/socketcan_interface/src/candump.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]){
     if(argc == 4 ){
         try
         {
-            g_loader = boost::make_shared<class_loader::ClassLoader>(argv[2]);
+            g_loader = make_shared<class_loader::ClassLoader>(argv[2]);
             g_driver = g_loader->createInstance<DriverInterface>(argv[3]);
         }
 
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]){
             return 1;
         }
     }else{
-        g_driver = boost::make_shared<SocketCANInterface>();
+        g_driver = make_shared<SocketCANInterface>();
     }
 
 

--- a/socketcan_interface/src/string.cpp
+++ b/socketcan_interface/src/string.cpp
@@ -131,7 +131,7 @@ Frame toframe(const std::string& s) {
 	return frame;
 }
 
-template<> FrameFilter::Ptr tofilter(const std::string  &s){
+template<> FrameFilterSharedPtr tofilter(const std::string  &s){
 	  FrameFilter * filter = 0;
 		size_t delim = s.find_first_of(":~-_");
 
@@ -156,13 +156,13 @@ template<> FrameFilter::Ptr tofilter(const std::string  &s){
 				filter = new FrameRangeFilter(first, second, invert);
 				break;
 		}
-		return FrameFilter::Ptr(filter);
+		return FrameFilterSharedPtr(filter);
 }
-template<> FrameFilter::Ptr tofilter(const uint32_t &id){
-		return FrameFilter::Ptr(new FrameMaskFilter(id));
+template<> FrameFilterSharedPtr tofilter(const uint32_t &id){
+		return FrameFilterSharedPtr(new FrameMaskFilter(id));
 }
 
-FrameFilter::Ptr tofilter(const char* s){
+FrameFilterSharedPtr tofilter(const char* s){
 		return tofilter<std::string>(s);
 }
 

--- a/socketcan_interface/test/test_dummy_interface.cpp
+++ b/socketcan_interface/test/test_dummy_interface.cpp
@@ -14,7 +14,7 @@ public:
    void handle(const can::Frame &f){
         responses.push_back(can::tostring(f, true));
     }
-    can::CommInterface::FrameListener::Ptr listener;
+    can::FrameListenerConstSharedPtr listener;
 };
 
 // Declare a test

--- a/socketcan_interface/test/test_filter.cpp
+++ b/socketcan_interface/test/test_filter.cpp
@@ -14,7 +14,7 @@ TEST(FilterTest, simpleMask)
   const std::string msg1("123#");
   const std::string msg2("124#");
 
-  can::FrameFilter::Ptr f1 = can::tofilter("123");
+  can::FrameFilterSharedPtr f1 = can::tofilter("123");
 
   EXPECT_TRUE(f1->pass(can::toframe(msg1)));
   EXPECT_FALSE(f1->pass(can::toframe(msg2)));
@@ -26,9 +26,9 @@ TEST(FilterTest, maskTests)
   const std::string msg2("124#");
   const std::string msg3("122#");
 
-  can::FrameFilter::Ptr f1 = can::tofilter("123:123");
-  can::FrameFilter::Ptr f2 = can::tofilter("123:ffe");
-  can::FrameFilter::Ptr f3 = can::tofilter("123~123");
+  can::FrameFilterSharedPtr f1 = can::tofilter("123:123");
+  can::FrameFilterSharedPtr f2 = can::tofilter("123:ffe");
+  can::FrameFilterSharedPtr f3 = can::tofilter("123~123");
 
   EXPECT_TRUE(f1->pass(can::toframe(msg1)));
   EXPECT_FALSE(f1->pass(can::toframe(msg2)));
@@ -51,9 +51,9 @@ TEST(FilterTest, rangeTest)
   const std::string msg2("125#");
   const std::string msg3("130#");
 
-  can::FrameFilter::Ptr f1 = can::tofilter("120-120");
-  can::FrameFilter::Ptr f2 = can::tofilter("120_120");
-  can::FrameFilter::Ptr f3 = can::tofilter("120-125");
+  can::FrameFilterSharedPtr f1 = can::tofilter("120-120");
+  can::FrameFilterSharedPtr f2 = can::tofilter("120_120");
+  can::FrameFilterSharedPtr f3 = can::tofilter("120-125");
 
   EXPECT_TRUE(f1->pass(can::toframe(msg1)));
   EXPECT_FALSE(f1->pass(can::toframe(msg2)));
@@ -82,12 +82,12 @@ TEST(FilterTest, listenerTest)
 {
 
   Counter counter;
-  boost::shared_ptr<can::CommInterface> dummy(new can::DummyInterface(true));
+  can::CommInterfaceSharedPtr dummy(new can::DummyInterface(true));
 
   can::FilteredFrameListener::FilterVector filters;
   filters.push_back(can::tofilter("123:FFE"));
 
-  can::CommInterface::FrameListener::Ptr  listener(new can::FilteredFrameListener(dummy,can::CommInterface::FrameDelegate(&counter, &Counter::count), filters));
+  can::FrameListenerConstSharedPtr  listener(new can::FilteredFrameListener(dummy,can::CommInterface::FrameDelegate(&counter, &Counter::count), filters));
 
   can::Frame f1 = can::toframe("123#");
   can::Frame f2 = can::toframe("124#");


### PR DESCRIPTION
preparation for #274 
closes #212 

* Consistent type name for all shared pointers, old names got deprecated
* Function types
* make_shared in `can` and `canopen` namespace for easier transition
* whitespace fixes
