### PR TITLE
Added state_switch_timeout parameter to motor.

### DIFF
--- a/canopen_402/include/canopen_402/motor.h
+++ b/canopen_402/include/canopen_402/motor.h
@@ -295,7 +295,8 @@ public:
     Motor402(const std::string &name, boost::shared_ptr<ObjectStorage> storage, const canopen::Settings &settings)
     : MotorBase(name), status_word_(0),control_word_(0),
       switching_state_(State402::InternalState(settings.get_optional<unsigned int>("switching_state", static_cast<unsigned int>(State402::Operation_Enable)))),
-      monitor_mode_(settings.get_optional<bool>("monitor_mode", true))
+      monitor_mode_(settings.get_optional<bool>("monitor_mode", true)),
+      state_switch_timeout_(settings.get_optional<unsigned int>("state_switch_timeout", 5))
     {
         storage->entry(status_word_entry_, 0x6041);
         storage->entry(control_word_entry_, 0x6040);
@@ -387,6 +388,7 @@ private:
     boost::mutex mode_mutex_;
     const State402::InternalState switching_state_;
     const bool monitor_mode_;
+    const boost::chrono::seconds state_switch_timeout_;
 
     canopen::ObjectStorage::Entry<uint16_t>  status_word_entry_;
     canopen::ObjectStorage::Entry<uint16_t >  control_word_entry_;

--- a/canopen_402/src/motor.cpp
+++ b/canopen_402/src/motor.cpp
@@ -353,7 +353,7 @@ bool Motor402::switchMode(LayerStatus &status, uint16_t mode) {
 }
 
 bool Motor402::switchState(LayerStatus &status, const State402::InternalState &target){
-    time_point abstime = get_abs_time(boost::chrono::seconds(5));
+    time_point abstime = get_abs_time(state_switch_timeout_);
     State402::InternalState state = state_handler_.getState();
     target_state_ = target;
     while(state != target_state_){


### PR DESCRIPTION
Enables users to set the timeout e.g.
<pre>
defaults: # optional, all defaults can be overwritten per node
  eds_pkg: my_config_package # optional package  name for relative path
  eds_file: "my_config.dcf" # path to EDS/DCF file
  <b>motor_layer:
    state_switch_timeout: 15</b>
  dcf_overlay: # "ObjectID": "ParameterValue" (both as strings)
    "1016sub1" : "0x7F0064" # heartbeat timeout of 100 ms for master at 127
    "1017": "100" # heartbeat producer
</pre>
currently defaults to 5s to ensure consistent behaviour on deployed systems.
