### PR TITLE
added C++11 flag for canopen_motor_node

### DIFF
--- a/canopen_motor_node/CMakeLists.txt
+++ b/canopen_motor_node/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(canopen_motor_node)
 
+set(CMAKE_CXX_STANDARD 11)
+
 find_package(catkin REQUIRED
   COMPONENTS
     canopen_402


### PR DESCRIPTION
I needed this change to compile for lunar on Ubuntu 16.04