### PR TITLE
Add functions to disable specific error types in SocketCANInterface

### DIFF
--- a/socketcan_interface/include/socketcan_interface/socketcan.h
+++ b/socketcan_interface/include/socketcan_interface/socketcan.h
@@ -199,11 +199,9 @@ protected:
             if(frame_.can_id & CAN_ERR_FLAG){ // error message
                 input_.id = frame_.can_id & CAN_EFF_MASK;
                 input_.is_error = 1;
-
                 LOG("error: " << input_.id);
-                setInternalError(input_.id);
-                setNotReady();
 
+                handleErrorFrame();
             }else{
                 input_.is_extended = (frame_.can_id & CAN_EFF_FLAG) ? 1 :0;
                 input_.id = frame_.can_id & (input_.is_extended ? CAN_EFF_MASK : CAN_SFF_MASK);
@@ -213,6 +211,11 @@ protected:
 
         }
         frameReceived(error);
+    }
+
+    virtual void handleErrorFrame(){
+        setInternalError(input_.id);
+        setNotReady();
     }
 private:
     boost::mutex send_mutex_;


### PR DESCRIPTION
Similar to #264, but so far limited to the SocketCANInterface only.

Saves the state of the CAN error mask within the object and provides two functions to disable lost arbitration and controller problems. These two have been added explicitly in order to not disable other errors by accident. A private function within SocketCANInterface still provides an internal, generic interface.

Could also be added to the socketcan bridge. I cannot test it though, because we are using the SocketCANInterface only.