### PR TITLE
If an error occurs try and recover from it if necessary

### DIFF
--- a/socketcan_bridge/src/topic_to_socketcan.cpp
+++ b/socketcan_bridge/src/topic_to_socketcan.cpp
@@ -69,7 +69,8 @@ namespace socketcan_bridge
       bool res = driver_->send(f);
       if (!res)
       {
-        ROS_ERROR("Failed to send message: %s.", can::tostring(f, true).c_str());
+        ROS_ERROR("Failed to send message: %s. Trying to recover.", can::tostring(f, true).c_str());
+        driver_->recover();
       }
     };
 


### PR DESCRIPTION
We were having issues with the driver refusing to send packets after an error of some type occurred on the bus, likely due to the hardware on the other end. Simply recovering was able to fix the problem. This is probably not the best way to do it, but it definitely works.

Related to #267 

It may be good to just add a parameter to enable or disable this functionality and merge it in as a stopgap until the fancier solution #249 is complete. This node is useless to us without this functionality.