### PR TITLE
Maint/roslint socketcan bridge

### DIFF
--- a/socketcan_bridge/CMakeLists.txt
+++ b/socketcan_bridge/CMakeLists.txt
@@ -99,8 +99,9 @@ if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   find_package(roslint REQUIRED)
 
+  # forces roslint when run_tests is executed
   roslint_cpp()
-  #for use with catkin_make roslint_socketcan_bridge
+  roslint_add_test()
 
   # unit test for the can_msgs::Frame and can::Frame types.
   catkin_add_gtest(test_conversion

--- a/socketcan_bridge/src/socketcan_to_topic.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic.cpp
@@ -30,98 +30,113 @@
 #include <can_msgs/Frame.h>
 #include <string>
 
-namespace can {
-template<> can::FrameFilterSharedPtr tofilter(const XmlRpc::XmlRpcValue  &ct) {
+namespace can
+{
+template<> can::FrameFilterSharedPtr tofilter(const XmlRpc::XmlRpcValue  &ct)
+{
   XmlRpc::XmlRpcValue t(ct);
-  try{ // to read as integer
-      uint32_t id = static_cast<int>(t);
-      return tofilter(id);
+  try
+  {  // to read as integer
+    uint32_t id = static_cast<int>(t);
+    return tofilter(id);
   }
-  catch(...){ // read as string
-      return  tofilter(static_cast<std::string>(t));
+  catch(...)
+  {  // read as string
+    return  tofilter(static_cast<std::string>(t));
   }
 }
-}
+}  // namespace can
 
 namespace socketcan_bridge
 {
-  SocketCANToTopic::SocketCANToTopic(ros::NodeHandle* nh, ros::NodeHandle* nh_param,
-      can::DriverInterfaceSharedPtr driver)
+
+SocketCANToTopic::SocketCANToTopic(
+  ros::NodeHandle* nh,
+  ros::NodeHandle* nh_param,
+  can::DriverInterfaceSharedPtr driver)
+{
+  can_topic_ = nh->advertise<can_msgs::Frame>("received_messages", 10);
+  driver_ = driver;
+}
+
+void SocketCANToTopic::setup()
+{
+  // register handler for frames and state changes.
+  frame_listener_ = driver_->createMsgListener(
+    can::CommInterface::FrameDelegate(this, &SocketCANToTopic::frameCallback));
+
+  state_listener_ = driver_->createStateListener(
+    can::StateInterface::StateDelegate(this, &SocketCANToTopic::stateCallback));
+}
+
+void SocketCANToTopic::setup(const can::FilteredFrameListener::FilterVector &filters)
+{
+  frame_listener_.reset(
+    new can::FilteredFrameListener(
+      driver_,
+      can::CommInterface::FrameDelegate(
+        this,
+        &SocketCANToTopic::frameCallback),
+      filters));
+
+  state_listener_ = driver_->createStateListener(
+    can::StateInterface::StateDelegate(this, &SocketCANToTopic::stateCallback));
+}
+
+void SocketCANToTopic::setup(XmlRpc::XmlRpcValue filters)
+{
+  setup(can::tofilters(filters));
+}
+
+void SocketCANToTopic::setup(ros::NodeHandle nh)
+{
+  XmlRpc::XmlRpcValue filters;
+  if (nh.getParam("can_ids", filters)) return setup(filters);
+  return setup();
+}
+
+void SocketCANToTopic::frameCallback(const can::Frame& f)
+{
+  // ROS_DEBUG("Message came in: %s", can::tostring(f, true).c_str());
+  if (!f.isValid())
+  {
+    ROS_ERROR("Invalid frame from SocketCAN: id: %#04x, length: %d, is_extended: %d, is_error: %d, is_rtr: %d",
+      f.id, f.dlc, f.is_extended, f.is_error, f.is_rtr);
+    return;
+  }
+  else
+  {
+    if (f.is_error)
     {
-      can_topic_ = nh->advertise<can_msgs::Frame>("received_messages", 10);
-      driver_ = driver;
-    };
-
-  void SocketCANToTopic::setup()
-    {
-      // register handler for frames and state changes.
-      frame_listener_ = driver_->createMsgListener(
-              can::CommInterface::FrameDelegate(this, &SocketCANToTopic::frameCallback));
-
-      state_listener_ = driver_->createStateListener(
-              can::StateInterface::StateDelegate(this, &SocketCANToTopic::stateCallback));
-    };
-
-  void SocketCANToTopic::setup(const can::FilteredFrameListener::FilterVector &filters){
-    frame_listener_.reset(new can::FilteredFrameListener(driver_,
-                                                         can::CommInterface::FrameDelegate(this, &SocketCANToTopic::frameCallback),
-                                                         filters));
-
-    state_listener_ = driver_->createStateListener(
-            can::StateInterface::StateDelegate(this, &SocketCANToTopic::stateCallback));
+      // can::tostring cannot be used for dlc > 8 frames. It causes an crash
+      // due to usage of boost::array for the data array. The should always work.
+      ROS_WARN("Received frame is error: %s", can::tostring(f, true).c_str());
+    }
   }
 
-  void SocketCANToTopic::setup(XmlRpc::XmlRpcValue filters) {
-      setup(can::tofilters(filters));
+  can_msgs::Frame msg;
+  // converts the can::Frame (socketcan.h) to can_msgs::Frame (ROS msg)
+  convertSocketCANToMessage(f, msg);
+
+  msg.header.frame_id = "";  // empty frame is the de-facto standard for no frame.
+  msg.header.stamp = ros::Time::now();
+
+  can_topic_.publish(msg);
+}
+
+void SocketCANToTopic::stateCallback(const can::State & s)
+{
+  std::string err;
+  driver_->translateError(s.internal_error, err);
+
+  if (!s.internal_error)
+  {
+    ROS_INFO("State: %s, asio: %s", err.c_str(), s.error_code.message().c_str());
   }
-  void SocketCANToTopic::setup(ros::NodeHandle nh) {
-       XmlRpc::XmlRpcValue filters;
-       if(nh.getParam("can_ids", filters)) return setup(filters);
-       return setup();
+  else
+  {
+    ROS_ERROR("Error: %s, asio: %s", err.c_str(), s.error_code.message().c_str());
   }
+}
 
-
-  void SocketCANToTopic::frameCallback(const can::Frame& f)
-    {
-      // ROS_DEBUG("Message came in: %s", can::tostring(f, true).c_str());
-      if (!f.isValid())
-      {
-        ROS_ERROR("Invalid frame from SocketCAN: id: %#04x, length: %d, is_extended: %d, is_error: %d, is_rtr: %d",
-                  f.id, f.dlc, f.is_extended, f.is_error, f.is_rtr);
-        return;
-      }
-      else
-      {
-        if (f.is_error)
-        {
-          // can::tostring cannot be used for dlc > 8 frames. It causes an crash
-          // due to usage of boost::array for the data array. The should always work.
-          ROS_WARN("Received frame is error: %s", can::tostring(f, true).c_str());
-        }
-      }
-
-      can_msgs::Frame msg;
-      // converts the can::Frame (socketcan.h) to can_msgs::Frame (ROS msg)
-      convertSocketCANToMessage(f, msg);
-
-      msg.header.frame_id = "";  // empty frame is the de-facto standard for no frame.
-      msg.header.stamp = ros::Time::now();
-
-      can_topic_.publish(msg);
-    };
-
-
-  void SocketCANToTopic::stateCallback(const can::State & s)
-    {
-      std::string err;
-      driver_->translateError(s.internal_error, err);
-      if (!s.internal_error)
-      {
-        ROS_INFO("State: %s, asio: %s", err.c_str(), s.error_code.message().c_str());
-      }
-      else
-      {
-        ROS_ERROR("Error: %s, asio: %s", err.c_str(), s.error_code.message().c_str());
-      }
-    };
 };  // namespace socketcan_bridge

--- a/socketcan_bridge/test/to_topic_test.cpp
+++ b/socketcan_bridge/test/to_topic_test.cpp
@@ -33,7 +33,10 @@
 
 #include <gtest/gtest.h>
 #include <ros/ros.h>
+
 #include <list>
+#include <string>
+#include <vector>
 
 class msgCollector
 {
@@ -48,7 +51,8 @@ class msgCollector
     }
 };
 
-std::string convertMessageToString(const can_msgs::Frame &msg, bool lc=true) {
+std::string convertMessageToString(const can_msgs::Frame &msg, bool lc = true)
+{
   can::Frame f;
   socketcan_bridge::convertMessageToSocketCAN(msg, f);
   return can::tostring(f, lc);
@@ -81,7 +85,8 @@ TEST(SocketCANToTopicTest, checkCorrectData)
   f.is_error = false;
   f.id = 0x1337;
   f.dlc = 8;
-  for (uint8_t i=0; i < f.dlc; i++)
+
+  for (uint8_t i = 0; i < f.dlc; i++)
   {
     f.data[i] = i;
   }
@@ -146,7 +151,7 @@ TEST(SocketCANToTopicTest, checkInvalidFrameHandling)
   EXPECT_EQ(message_collector_.messages.size(), 0);
 
   f.is_extended = true;
-  f.id = (1<<11)+1;  // now it should be alright.
+  f.id = (1 << 11) + 1;  // now it should be alright.
 
   driver_->send(f);
   ros::WallDuration(1.0).sleep();
@@ -161,7 +166,7 @@ TEST(SocketCANToTopicTest, checkCorrectCanIdFilter)
   // create the dummy interface
   can::DummyInterfaceSharedPtr driver_ = std::make_shared<can::DummyInterface>(true);
 
-  //create can_id vector with id that should be passed and published to ros
+  // create can_id vector with id that should be passed and published to ros
   std::vector<unsigned int> pass_can_ids;
   pass_can_ids.push_back(0x1337);
 
@@ -185,7 +190,8 @@ TEST(SocketCANToTopicTest, checkCorrectCanIdFilter)
   f.is_error = false;
   f.id = 0x1337;
   f.dlc = 8;
-  for (uint8_t i=0; i < f.dlc; i++)
+
+  for (uint8_t i = 0; i < f.dlc; i++)
   {
     f.data[i] = i;
   }
@@ -219,7 +225,7 @@ TEST(SocketCANToTopicTest, checkInvalidCanIdFilter)
   // create the dummy interface
   can::DummyInterfaceSharedPtr driver_ = std::make_shared<can::DummyInterface>(true);
 
-  //create can_id vector with id that should not be received on can bus
+  // create can_id vector with id that should not be received on can bus
   std::vector<unsigned int> pass_can_ids;
   pass_can_ids.push_back(0x300);
 
@@ -243,7 +249,8 @@ TEST(SocketCANToTopicTest, checkInvalidCanIdFilter)
   f.is_error = false;
   f.id = 0x1337;
   f.dlc = 8;
-  for (uint8_t i=0; i < f.dlc; i++)
+
+  for (uint8_t i = 0; i < f.dlc; i++)
   {
     f.data[i] = i;
   }


### PR DESCRIPTION
Fixes linter errors in socketcan_bridge and adds the roslint hook to run_tests. This means that any roslint errors will cause a failed build in CI. This is not required but is _strongly encouraged_ in ROS2. It's also just generally good practice.