### PR TITLE
reset node on initialization

### DIFF
--- a/canopen_master/src/node.cpp
+++ b/canopen_master/src/node.cpp
@@ -178,7 +178,7 @@ void Node::handleInit(LayerStatus &status){
 
     sdo_.init();
     try{
-        if(!reset_com()) BOOST_THROW_EXCEPTION( TimeoutException("reset_timeout") );
+        if(!reset()) BOOST_THROW_EXCEPTION( TimeoutException("reset_timeout") );
     }
     catch(const TimeoutException&){
         status.error(boost::str(boost::format("could not reset node '%1%'") % (int)node_id_));


### PR DESCRIPTION
Resetting the communication only loads default values for the pdo mapping in the motor firmware according to CiA 301. I suggest with this PR to also reset the application registers to get a roslaunch behaviour that is similar to a power-on-reset of the motor (firmware) to fully recover from errors and values from the previous run.

What do you think?