### PR TITLE
Log output of /init and /recover services

### DIFF
--- a/canopen_chain_node/src/ros_chain.cpp
+++ b/canopen_chain_node/src/ros_chain.cpp
@@ -107,6 +107,7 @@ bool RosChain::handle_init(std_srvs::Trigger::Request  &req, std_srvs::Trigger::
         if(!status.bounded<LayerStatus::Warn>()){
             diag(status);
             res.message = status.reason();
+            ROS_WARN_STREAM(status.reason());
         }else{
             heartbeat_timer_.restart();
             return true;
@@ -144,6 +145,7 @@ bool RosChain::handle_recover(std_srvs::Trigger::Request  &req, std_srvs::Trigge
             }
             res.success = status.bounded<LayerStatus::Warn>();
             res.message = status.reason();
+            ROS_WARN_STREAM(status.reason());
         }
         catch( const std::exception &e){
             std::string info = boost::diagnostic_information(e);

--- a/canopen_chain_node/src/ros_chain.cpp
+++ b/canopen_chain_node/src/ros_chain.cpp
@@ -107,7 +107,6 @@ bool RosChain::handle_init(std_srvs::Trigger::Request  &req, std_srvs::Trigger::
         if(!status.bounded<LayerStatus::Warn>()){
             diag(status);
             res.message = status.reason();
-            ROS_WARN_STREAM(status.reason());
         }else{
             heartbeat_timer_.restart();
             return true;
@@ -125,6 +124,7 @@ bool RosChain::handle_init(std_srvs::Trigger::Request  &req, std_srvs::Trigger::
     }
 
     res.success = false;
+    ROS_WARN_STREAM("Initialization failed: " << res.message);
     shutdown(status);
 
     return true;
@@ -145,7 +145,6 @@ bool RosChain::handle_recover(std_srvs::Trigger::Request  &req, std_srvs::Trigge
             }
             res.success = status.bounded<LayerStatus::Warn>();
             res.message = status.reason();
-            ROS_WARN_STREAM(status.reason());
         }
         catch( const std::exception &e){
             std::string info = boost::diagnostic_information(e);
@@ -157,6 +156,9 @@ bool RosChain::handle_recover(std_srvs::Trigger::Request  &req, std_srvs::Trigge
         }
     }else{
         res.message = "not running";
+    }
+    if(!res.success){
+        ROS_ERROR_STREAM("Recover failed: " << res.message);
     }
     return true;
 }


### PR DESCRIPTION
Duplicate the reason that is put into the service response string onto
the terminal in case of failures.
Implements #319