### PR TITLE
Option to ignore error frames

### DIFF
--- a/canopen_chain_node/src/ros_chain.cpp
+++ b/canopen_chain_node/src/ros_chain.cpp
@@ -1,5 +1,6 @@
 #include <ros/package.h>
 
+#include <socketcan_interface/xmlrpc_settings.h>
 #include <canopen_chain_node/ros_chain.h>
 
 #include <std_msgs/Int8.h>
@@ -325,7 +326,7 @@ bool RosChain::setup_bus(){
         return false;
     }
 
-    add(std::make_shared<CANLayer>(interface_, can_device, loopback));
+    add(std::make_shared<CANLayer>(interface_, can_device, loopback, XmlRpcSettings::create(bus_nh)));
 
     return true;
 }

--- a/canopen_chain_node/src/sync_node.cpp
+++ b/canopen_chain_node/src/sync_node.cpp
@@ -1,5 +1,6 @@
 #include <canopen_master/bcm_sync.h>
 #include <socketcan_interface/string.h>
+#include <socketcan_interface/xmlrpc_settings.h>
 #include <canopen_master/can_layer.h>
 #include <ros/ros.h>
 #include <diagnostic_updater/diagnostic_updater.h>
@@ -86,7 +87,7 @@ int main(int argc, char** argv){
 
     canopen::LayerStack stack("SyncNodeLayer");
 
-    stack.add(std::make_shared<canopen::CANLayer>(driver, can_device, false));
+    stack.add(std::make_shared<canopen::CANLayer>(driver, can_device, false, XmlRpcSettings::create(nh_priv, "bus")));
     stack.add(sync);
 
     diagnostic_updater::Updater diag_updater(nh, nh_priv);

--- a/canopen_master/include/canopen_master/canopen.h
+++ b/canopen_master/include/canopen_master/canopen.h
@@ -325,26 +325,7 @@ public:
 };
 typedef Master::MasterSharedPtr MasterSharedPtr;
 
-class Settings
-{
-public:
-    template <typename T> T get_optional(const std::string &n, const T& def) const {
-        std::string repr;
-        if(!getRepr(n, repr)){
-            return def;
-        }
-        return boost::lexical_cast<T>(repr);
-    }
-    template <typename T> bool get(const std::string &n, T& val) const {
-        std::string repr;
-        if(!getRepr(n, repr)) return false;
-        val =  boost::lexical_cast<T>(repr);
-        return true;
-    }
-    virtual ~Settings() {}
-private:
-    virtual bool getRepr(const std::string &n, std::string & repr) const = 0;
-};
+using can::Settings;
 
 } // canopen
 #endif // !H_CANOPEN

--- a/canopen_master/src/bcm_sync.cpp
+++ b/canopen_master/src/bcm_sync.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv){
     }
 
     can::SocketCANDriverSharedPtr driver = std::make_shared<can::SocketCANDriver>();
-    if(!driver->init(can_device, false)){
+    if(!driver->init(can_device, false, can::NoSettings::create())){
         std::cout << "Could not initialize CAN" << std::endl;
         return 1;
     }

--- a/canopen_motor_node/src/motor_chain.cpp
+++ b/canopen_motor_node/src/motor_chain.cpp
@@ -1,29 +1,8 @@
 
 #include <canopen_motor_node/motor_chain.h>
 #include <canopen_motor_node/handle_layer.h>
-
+#include <socketcan_interface/xmlrpc_settings.h>
 using namespace canopen;
-
-
-class XmlRpcSettings : public Settings{
-public:
-    XmlRpcSettings() {}
-    XmlRpcSettings(const XmlRpc::XmlRpcValue &v) : value_(v) {}
-    XmlRpcSettings& operator=(const XmlRpc::XmlRpcValue &v) { value_ = v; return *this; }
-private:
-    virtual bool getRepr(const std::string &n, std::string & repr) const {
-        if(value_.hasMember(n)){
-            std::stringstream sstr;
-            sstr << const_cast< XmlRpc::XmlRpcValue &>(value_)[n]; // does not write since already existing
-            repr = sstr.str();
-            return true;
-        }
-        return false;
-    }
-    XmlRpc::XmlRpcValue value_;
-
-};
-
 
 MotorChain::MotorChain(const ros::NodeHandle &nh, const ros::NodeHandle &nh_priv) :
         RosChain(nh, nh_priv), motor_allocator_("canopen_402", "canopen::MotorBase::Allocator") {}

--- a/socketcan_bridge/src/socketcan_bridge_node.cpp
+++ b/socketcan_bridge/src/socketcan_bridge_node.cpp
@@ -29,6 +29,7 @@
 #include <socketcan_bridge/topic_to_socketcan.h>
 #include <socketcan_bridge/socketcan_to_topic.h>
 #include <socketcan_interface/threading.h>
+#include <socketcan_interface/xmlrpc_settings.h>
 #include <memory>
 #include <string>
 
@@ -44,7 +45,8 @@ int main(int argc, char *argv[])
 
   can::ThreadedSocketCANInterfaceSharedPtr driver = std::make_shared<can::ThreadedSocketCANInterface> ();
 
-  if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
+  // initialize device at can_device, 0 for no loopback.
+  if (!driver->init(can_device, 0, XmlRpcSettings::create(nh_param)))
   {
     ROS_FATAL("Failed to initialize can_device at %s", can_device.c_str());
     return 1;

--- a/socketcan_bridge/src/socketcan_to_topic_node.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic_node.cpp
@@ -29,6 +29,7 @@
 #include <socketcan_bridge/socketcan_to_topic.h>
 #include <socketcan_interface/threading.h>
 #include <socketcan_interface/string.h>
+#include <socketcan_interface/xmlrpc_settings.h>
 #include <memory>
 #include <string>
 
@@ -45,7 +46,8 @@ int main(int argc, char *argv[])
 
   can::ThreadedSocketCANInterfaceSharedPtr driver = std::make_shared<can::ThreadedSocketCANInterface> ();
 
-  if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
+  // initialize device at can_device, 0 for no loopback.
+  if (!driver->init(can_device, 0, XmlRpcSettings::create(nh_param)))
   {
     ROS_FATAL("Failed to initialize can_device at %s", can_device.c_str());
     return 1;

--- a/socketcan_bridge/src/topic_to_socketcan_node.cpp
+++ b/socketcan_bridge/src/topic_to_socketcan_node.cpp
@@ -29,6 +29,7 @@
 #include <socketcan_bridge/topic_to_socketcan.h>
 #include <socketcan_interface/threading.h>
 #include <socketcan_interface/string.h>
+#include <socketcan_interface/xmlrpc_settings.h>
 #include <memory>
 #include <string>
 
@@ -45,7 +46,8 @@ int main(int argc, char *argv[])
 
   can::ThreadedSocketCANInterfaceSharedPtr driver = std::make_shared<can::ThreadedSocketCANInterface> ();
 
-  if (!driver->init(can_device, 0))  // initialize device at can_device, 0 for no loopback.
+  // initialize device at can_device, 0 for no loopback.
+  if (!driver->init(can_device, 0, XmlRpcSettings::create(nh_param)))
   {
     ROS_FATAL("Failed to initialize can_device at %s", can_device.c_str());
     return 1;

--- a/socketcan_interface/CMakeLists.txt
+++ b/socketcan_interface/CMakeLists.txt
@@ -104,6 +104,7 @@ install(
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 if(CATKIN_ENABLE_TESTING)
+  find_package(xmlrpcpp REQUIRED)
 
   catkin_add_gtest(${PROJECT_NAME}-test_dummy_interface
     test/test_dummy_interface.cpp
@@ -125,9 +126,13 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(${PROJECT_NAME}-test_settings
     test/test_settings.cpp
   )
+  target_include_directories(${PROJECT_NAME}-test_settings PRIVATE
+    ${xmlrpcpp_INCLUDE_DIRS}
+  )
   target_link_libraries(${PROJECT_NAME}-test_settings
     ${PROJECT_NAME}_string
     ${catkin_LIBRARIES}
+    ${xmlrpcpp_LIBRARIES}
   )
 
   catkin_add_gtest(${PROJECT_NAME}-test_string

--- a/socketcan_interface/CMakeLists.txt
+++ b/socketcan_interface/CMakeLists.txt
@@ -122,6 +122,14 @@ if(CATKIN_ENABLE_TESTING)
     ${catkin_LIBRARIES}
   )
 
+  catkin_add_gtest(${PROJECT_NAME}-test_settings
+    test/test_settings.cpp
+  )
+  target_link_libraries(${PROJECT_NAME}-test_settings
+    ${PROJECT_NAME}_string
+    ${catkin_LIBRARIES}
+  )
+
   catkin_add_gtest(${PROJECT_NAME}-test_string
     test/test_string.cpp
   )

--- a/socketcan_interface/include/socketcan_interface/interface.h
+++ b/socketcan_interface/include/socketcan_interface/interface.h
@@ -8,6 +8,7 @@
 #include <boost/system/error_code.hpp>
 
 #include "socketcan_interface/delegates.h"
+#include "socketcan_interface/settings.h"
 
 namespace can{
 

--- a/socketcan_interface/include/socketcan_interface/interface.h
+++ b/socketcan_interface/include/socketcan_interface/interface.h
@@ -8,6 +8,7 @@
 #include <boost/system/error_code.hpp>
 
 #include "socketcan_interface/delegates.h"
+#include "socketcan_interface/logging.h"
 #include "socketcan_interface/settings.h"
 
 namespace can{
@@ -174,17 +175,25 @@ public:
 using CommInterfaceSharedPtr = std::shared_ptr<CommInterface>;
 using FrameListenerConstSharedPtr = CommInterface::FrameListenerConstSharedPtr;
 
-
 class DriverInterface : public CommInterface, public StateInterface {
 public:
+    [[deprecated("provide settings explicitly")]]  virtual bool init(const std::string &device, bool loopback) = 0;
+
     /**
      * initialize interface
      *
      * @param[in] device: driver-specific device name/path
      * @param[in] loopback: loop-back own messages
+     * @param[in] settings: driver-specific settings
      * @return true if device was initialized succesfully, false otherwise
      */
-    virtual bool init(const std::string &device, bool loopback) = 0;
+    virtual bool init(const std::string &device, bool loopback, SettingsConstSharedPtr settings) {
+        ROSCANOPEN_ERROR("socketcan_interface", "Driver does not support custom settings");
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        return init(device, loopback);
+        #pragma GCC diagnostic pop
+    }
 
     /**
      * Recover interface after errors and emergency stops
@@ -217,7 +226,5 @@ using DriverInterfaceSharedPtr = std::shared_ptr<DriverInterface>;
 
 
 } // namespace can
-
-#include "logging.h"
 
 #endif

--- a/socketcan_interface/include/socketcan_interface/settings.h
+++ b/socketcan_interface/include/socketcan_interface/settings.h
@@ -1,0 +1,32 @@
+#ifndef SOCKETCAN_INTERFACE_SETTINGS_H
+#define SOCKETCAN_INTERFACE_SETTINGS_H
+
+#include <map>
+#include <string>
+#include <boost/lexical_cast.hpp>
+
+namespace can {
+  class Settings
+  {
+  public:
+      template <typename T> T get_optional(const std::string &n, const T& def) const {
+          std::string repr;
+          if(!getRepr(n, repr)){
+              return def;
+          }
+          return boost::lexical_cast<T>(repr);
+      }
+      template <typename T> bool get(const std::string &n, T& val) const {
+          std::string repr;
+          if(!getRepr(n, repr)) return false;
+          val =  boost::lexical_cast<T>(repr);
+          return true;
+      }
+      virtual ~Settings() {}
+  private:
+    virtual bool getRepr(const std::string &n, std::string & repr) const = 0;
+  };
+
+} // can
+
+#endif

--- a/socketcan_interface/include/socketcan_interface/settings.h
+++ b/socketcan_interface/include/socketcan_interface/settings.h
@@ -3,6 +3,8 @@
 
 #include <map>
 #include <string>
+#include <memory>
+
 #include <boost/lexical_cast.hpp>
 
 namespace can {
@@ -26,6 +28,31 @@ namespace can {
   private:
     virtual bool getRepr(const std::string &n, std::string & repr) const = 0;
   };
+  using SettingsConstSharedPtr = std::shared_ptr<const Settings>;
+  using SettingsSharedPtr = std::shared_ptr<Settings>;
+
+  class NoSettings : public Settings {
+  public:
+      static SettingsConstSharedPtr create() { return SettingsConstSharedPtr(new NoSettings); }
+  private:
+      virtual bool getRepr(const std::string &n, std::string & repr) const { return false; }
+  };
+
+  class SettingsMap : public Settings {
+    std::map<std::string, std::string> settings_;
+    virtual bool getRepr(const std::string &n, std::string & repr) const {
+      std::map<std::string, std::string>::const_iterator it = settings_.find(n);
+      if (it == settings_.cend()) return false;
+      repr = it->second;
+      return true;
+    }
+  public:
+    template <typename T> void set(const std::string &n, const T& val) {
+        settings_[n] = boost::lexical_cast<std::string>(val);
+    }
+    static std::shared_ptr<SettingsMap> create() { return std::shared_ptr<SettingsMap>(new SettingsMap); }
+  };
+
 
 } // can
 

--- a/socketcan_interface/include/socketcan_interface/socketcan.h
+++ b/socketcan_interface/include/socketcan_interface/socketcan.h
@@ -31,8 +31,7 @@ public:
     virtual bool doesLoopBack() const{
         return loopback_;
     }
-
-    virtual bool init(const std::string &device, bool loopback){
+    virtual bool init(const std::string &device, bool loopback) override {
         State s = getState();
         if(s.driver_state == State::closed){
             sc_ = 0;
@@ -112,6 +111,9 @@ public:
             return true;
         }
         return getState().isReady();
+    }
+    virtual bool init(const std::string &device, bool loopback, can::SettingsConstSharedPtr){
+      return init(device, loopback);
     }
     virtual bool recover(){
         if(!getState().isReady()){

--- a/socketcan_interface/include/socketcan_interface/xmlrpc_settings.h
+++ b/socketcan_interface/include/socketcan_interface/xmlrpc_settings.h
@@ -1,5 +1,6 @@
 #ifndef SOCKETCAN_INTERFACE_XMLRPC_SETTINGS_H
 #define SOCKETCAN_INTERFACE_XMLRPC_SETTINGS_H
+#include <socketcan_interface/logging.h>
 
 #include <socketcan_interface/settings.h>
 #include "xmlrpcpp/XmlRpcValue.h"
@@ -12,10 +13,20 @@ public:
     XmlRpcSettings(const XmlRpc::XmlRpcValue &v) : value_(v) {}
     XmlRpcSettings& operator=(const XmlRpc::XmlRpcValue &v) { value_ = v; return *this; }
 private:
-    virtual bool getRepr(const std::string &n, std::string & repr) const {
-        if(value_.hasMember(n)){
+    virtual bool getRepr(const std::string &name, std::string & repr) const {
+        const XmlRpc::XmlRpcValue *value = &value_;
+
+        std::string n = name;
+        size_t delim_pos;
+        while (value->getType() == XmlRpc::XmlRpcValue::TypeStruct && (delim_pos = n.find('/')) != std::string::npos){
+            std::string segment = n.substr(0, delim_pos);
+            if (!value->hasMember(segment)) return false;
+            value = &((*value)[segment]);
+            n.erase(0, delim_pos+1);
+        }
+        if(value->hasMember(n)){
             std::stringstream sstr;
-            sstr << const_cast< XmlRpc::XmlRpcValue &>(value_)[n]; // does not write since already existing
+            sstr << (*value)[n];
             repr = sstr.str();
             return true;
         }

--- a/socketcan_interface/include/socketcan_interface/xmlrpc_settings.h
+++ b/socketcan_interface/include/socketcan_interface/xmlrpc_settings.h
@@ -1,0 +1,28 @@
+#ifndef SOCKETCAN_INTERFACE_XMLRPC_SETTINGS_H
+#define SOCKETCAN_INTERFACE_XMLRPC_SETTINGS_H
+
+#include <socketcan_interface/settings.h>
+#include "xmlrpcpp/XmlRpcValue.h"
+#include <sstream>
+#include <string>
+
+class XmlRpcSettings : public can::Settings {
+public:
+    XmlRpcSettings() {}
+    XmlRpcSettings(const XmlRpc::XmlRpcValue &v) : value_(v) {}
+    XmlRpcSettings& operator=(const XmlRpc::XmlRpcValue &v) { value_ = v; return *this; }
+private:
+    virtual bool getRepr(const std::string &n, std::string & repr) const {
+        if(value_.hasMember(n)){
+            std::stringstream sstr;
+            sstr << const_cast< XmlRpc::XmlRpcValue &>(value_)[n]; // does not write since already existing
+            repr = sstr.str();
+            return true;
+        }
+        return false;
+    }
+    XmlRpc::XmlRpcValue value_;
+
+};
+
+#endif

--- a/socketcan_interface/include/socketcan_interface/xmlrpc_settings.h
+++ b/socketcan_interface/include/socketcan_interface/xmlrpc_settings.h
@@ -12,6 +12,11 @@ public:
     XmlRpcSettings() {}
     XmlRpcSettings(const XmlRpc::XmlRpcValue &v) : value_(v) {}
     XmlRpcSettings& operator=(const XmlRpc::XmlRpcValue &v) { value_ = v; return *this; }
+    template<typename T> static can::SettingsConstSharedPtr create(T nh, const std::string &ns="/") {
+        std::shared_ptr<XmlRpcSettings> settings(new XmlRpcSettings);
+        nh.getParam(ns, settings->value_);
+        return settings;
+    }
 private:
     virtual bool getRepr(const std::string &name, std::string & repr) const {
         const XmlRpc::XmlRpcValue *value = &value_;

--- a/socketcan_interface/package.xml
+++ b/socketcan_interface/package.xml
@@ -21,6 +21,7 @@
   <depend>linux-kernel-headers</depend>
 
   <test_depend>rosunit</test_depend>
+  <test_depend>xmlrpcpp</test_depend>
 
   <export>
     <socketcan_interface plugin="${prefix}/socketcan_interface_plugin.xml" />

--- a/socketcan_interface/src/candump.cpp
+++ b/socketcan_interface/src/candump.cpp
@@ -74,7 +74,7 @@ int main(int argc, char *argv[]){
     FrameListenerConstSharedPtr frame_printer = g_driver->createMsgListener(print_frame);
     StateListenerConstSharedPtr error_printer = g_driver->createStateListener(print_state);
 
-    if(!g_driver->init(argv[1], false)){
+    if(!g_driver->init(argv[1], false, can::NoSettings::create())){
         print_state(g_driver->getState());
         return 1;
     }

--- a/socketcan_interface/test/test_settings.cpp
+++ b/socketcan_interface/test/test_settings.cpp
@@ -1,0 +1,62 @@
+// Bring in my package's API, which is what I'm testing
+#include <socketcan_interface/settings.h>
+#include <socketcan_interface/socketcan.h>
+
+// Bring in gtest
+#include <gtest/gtest.h>
+
+TEST(SettingTest, socketcan_masks)
+{
+  const can_err_mask_t fatal_errors = ( CAN_ERR_TX_TIMEOUT   /* TX timeout (by netdevice driver) */
+                                      | CAN_ERR_BUSOFF       /* bus off */
+                                      | CAN_ERR_BUSERROR     /* bus error (may flood!) */
+                                      | CAN_ERR_RESTARTED    /* controller restarted */
+                                        );
+  const can_err_mask_t report_errors = ( CAN_ERR_LOSTARB      /* lost arbitration    / data[0]    */
+                                       | CAN_ERR_CRTL         /* controller problems / data[1]    */
+                                       | CAN_ERR_PROT         /* protocol violations / data[2..3] */
+                                       | CAN_ERR_TRX          /* transceiver status  / data[4]    */
+                                       | CAN_ERR_ACK          /* received no ACK on transmission */
+                                       );
+  can::SocketCANInterface sci;
+
+  // defaults
+  sci.init("None", false, can::NoSettings::create());
+  EXPECT_EQ(sci.getErrorMask(), fatal_errors | report_errors);
+  EXPECT_EQ(sci.getFatalErrorMask(), fatal_errors);
+
+  // remove report-only flag
+  auto m1 = can::SettingsMap::create();
+  m1->set("error_mask/CAN_ERR_LOSTARB", false);
+  sci.init("None", false, m1);
+  EXPECT_EQ(sci.getErrorMask(), (fatal_errors | report_errors) & (~CAN_ERR_LOSTARB));
+  EXPECT_EQ(sci.getFatalErrorMask(), fatal_errors);
+
+  // cannot remove fatal flag from report only
+  auto m2 = can::SettingsMap::create();
+  m2->set("error_mask/CAN_ERR_TX_TIMEOUT", false);
+  sci.init("None", false, m2);
+  EXPECT_EQ(sci.getErrorMask(), (fatal_errors | report_errors));
+  EXPECT_EQ(sci.getFatalErrorMask(), fatal_errors);
+
+  // remove fatal flag
+  auto m3 = can::SettingsMap::create();
+  m3->set("fatal_error_mask/CAN_ERR_TX_TIMEOUT", false);
+  sci.init("None", false, m3);
+  EXPECT_EQ(sci.getErrorMask(), (fatal_errors | report_errors) & (~CAN_ERR_TX_TIMEOUT));
+  EXPECT_EQ(sci.getFatalErrorMask(), fatal_errors & (~CAN_ERR_TX_TIMEOUT));
+
+  // remove fatal and report flag
+  auto m4 = can::SettingsMap::create();
+  m4->set("fatal_error_mask/CAN_ERR_TX_TIMEOUT", false);
+  m4->set("error_mask/CAN_ERR_LOSTARB", false);
+  sci.init("None", false, m4);
+  EXPECT_EQ(sci.getErrorMask(), (fatal_errors | report_errors) & ~(CAN_ERR_TX_TIMEOUT|CAN_ERR_LOSTARB));
+  EXPECT_EQ(sci.getFatalErrorMask(), fatal_errors & (~CAN_ERR_TX_TIMEOUT));
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char **argv){
+testing::InitGoogleTest(&argc, argv);
+return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Alternative to #264 with proper interface definition
Parameter parsing is not implemented yet.

ToDo:
- [x] implement parameter parsing for ROS packages
- [x] supppress `CAN_ERR_LOSTARB` by default
- [x] test, test, test