### PR TITLE
Can FD support

### DIFF
--- a/can_msgs/msg/Frame.msg
+++ b/can_msgs/msg/Frame.msg
@@ -4,4 +4,6 @@ bool is_rtr
 bool is_extended
 bool is_error
 uint8 dlc
-uint8[8] data
+uint8[] data
+
+uint8 DLC_FD_BRS_FLAG = 128

--- a/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
+++ b/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
@@ -64,9 +64,11 @@ void convertSocketCANToMessage(const can::Frame& f, can_msgs::Frame& m)
   m.is_rtr = f.is_rtr;
   m.is_extended = f.is_extended;
 
-  for (int i = 0; i < 8; i++)  // always copy all data, regardless of dlc.
+  m.data.reserve(f.dlc);
+
+  for (int i = 0; i < f.dlc; i++)
   {
-    m.data[i] = f.data[i];
+    m.data.push_back(f.data[i]);
   }
 };
 

--- a/socketcan_bridge/test/test_conversion.cpp
+++ b/socketcan_bridge/test/test_conversion.cpp
@@ -95,7 +95,7 @@ TEST(ConversionTest, topicToSocketCANStandard)
   m.is_extended = false;
   for (uint8_t i = 0; i < m.dlc; ++i)
   {
-    m.data[i] = i;
+    m.data.push_back(i);
   }
   socketcan_bridge::convertMessageToSocketCAN(m, f);
   EXPECT_EQ(127, f.id);

--- a/socketcan_interface/include/socketcan_interface/bcm.h
+++ b/socketcan_interface/include/socketcan_interface/bcm.h
@@ -18,28 +18,33 @@
 
 namespace can {
 
+typedef struct {
+    struct bcm_msg_head msg_head;
+    struct canfd_frame frames[0];
+} bcm_fdmsg_head;
+
 class BCMsocket{
     int s_;
     struct Message {
         size_t size;
         uint8_t *data;
-        Message(size_t n)
-        : size(sizeof(bcm_msg_head) + sizeof(can_frame)*n), data(new uint8_t[size])
+        Message(size_t n, bool is_fd)
+        : size(sizeof(bcm_msg_head) + (is_fd?sizeof(canfd_frame):sizeof(can_frame))*n), data(new uint8_t[size])
         {
             assert(n<=256);
             std::memset(data, 0, size);
-            head().nframes = n;
+            head()->nframes = n;
         }
-        bcm_msg_head& head() {
-            return *(bcm_msg_head*)data;
+        bcm_msg_head* head() {
+            return (bcm_msg_head*)data;
         }
         template<typename T> void setIVal2(T period){
             long long usec = boost::chrono::duration_cast<boost::chrono::microseconds>(period).count();
-            head().ival2.tv_sec = usec / 1000000;
-            head().ival2.tv_usec = usec % 1000000;
+            head()->ival2.tv_sec = usec / 1000000;
+            head()->ival2.tv_usec = usec % 1000000;
         }
         void setHeader(Header header){
-            head().can_id = header.id | (header.is_extended?CAN_EFF_FLAG:0);
+            head()->can_id = header.id | (header.is_extended?CAN_EFF_FLAG:0);
         }
         bool write(int s){
             return ::write(s, data, size) > 0;
@@ -79,27 +84,44 @@ public:
         return true;
     }
     template<typename DurationType> bool startTX(DurationType period, Header header, size_t num, Frame *frames) {
-        Message msg(num);
+        Message msg(num, header.is_fd);
         msg.setHeader(header);
         msg.setIVal2(period);
 
-        bcm_msg_head &head = msg.head();
+        if (header.is_fd){
+            bcm_fdmsg_head* head = (bcm_fdmsg_head*)msg.head();
 
-        head.opcode = TX_SETUP;
-        head.flags |= SETTIMER | STARTTIMER;
+            head->msg_head.opcode = TX_SETUP;
+            head->msg_head.flags |= SETTIMER | STARTTIMER | CAN_FD_FRAME;
 
-        for(size_t i=0; i < num; ++i){ // msg nr
-            head.frames[i].can_dlc = frames[i].dlc;
-            head.frames[i].can_id = head.can_id;
-            for(size_t j = 0; j < head.frames[i].can_dlc; ++j){ // byte nr
-                head.frames[i].data[j] = frames[i].data[j];
+            for(size_t i=0; i < num; ++i){ // msg nr
+                head->frames[i].len = frames[i].dlc;
+                head->frames[i].can_id = head->msg_head.can_id;
+                head->frames[i].flags = header.flags;
+                for(size_t j = 0; j < head->frames[i].len; ++j){ // byte nr
+                    head->frames[i].data[j] = frames[i].data[j];
+                }
+            }
+        } else {
+            bcm_msg_head* head = msg.head();
+
+            head->opcode = TX_SETUP;
+            head->flags |= SETTIMER | STARTTIMER;
+
+            for(size_t i=0; i < num; ++i){ // msg nr
+                head->frames[i].can_dlc = frames[i].dlc;
+                head->frames[i].can_id = head->can_id;
+                for(size_t j = 0; j < head->frames[i].can_dlc; ++j){ // byte nr
+                    head->frames[i].data[j] = frames[i].data[j];
+                }
             }
         }
+
         return msg.write(s_);
     }
     bool stopTX(Header header){
-        Message msg(0);
-        msg.head().opcode = TX_DELETE;
+        Message msg(0, false);
+        msg.head()->opcode = TX_DELETE;
         msg.setHeader(header);
         return msg.write(s_);
     }

--- a/socketcan_interface/src/candump.cpp
+++ b/socketcan_interface/src/candump.cpp
@@ -16,6 +16,8 @@ void print_frame(const Frame &f){
         std::cout << "E " << std::hex << f.id << std::dec;
     }else if(f.is_extended){
         std::cout << "e " << std::hex << f.id << std::dec;
+    }else if(f.is_fd){
+        std::cout << "f " << std::hex << f.id << std::dec;
     }else{
         std::cout << "s " << std::hex << f.id << std::dec;
     }

--- a/socketcan_interface/test/test_string.cpp
+++ b/socketcan_interface/test/test_string.cpp
@@ -5,16 +5,22 @@
 #include <gtest/gtest.h>
 
 
-TEST(StringTest, stringconversion)
+TEST(StringTest, stringConversion1)
 {
   const std::string s1("123#1234567812345678");
   can::Frame f1 = can::toframe(s1);
   EXPECT_EQ(s1, can::tostring(f1, true));
+}
 
+TEST(StringTest, stringConversion2)
+{
   const std::string s2("1337#1234567812345678");
   can::Frame f2 = can::toframe(s2);
   EXPECT_FALSE(f2.isValid());
+}
 
+TEST(StringTest, stringConversion3)
+{
   const std::string s3("80001337#1234567812345678");
   const std::string s4("00001337#1234567812345678");
 
@@ -29,21 +35,37 @@ TEST(StringTest, stringconversion)
   EXPECT_TRUE(f4.isValid());
   EXPECT_TRUE(f4.is_extended);
   EXPECT_EQ(s4, can::tostring(f4, true));
+}
 
+TEST(StringTest, stringConversion4)
+{
   const std::string s5("20001337#1234567812345678");
   can::Frame f5 = can::toframe(s5);
   EXPECT_EQ(f5.fullid(), 0xA0001337);
   EXPECT_TRUE(f5.isValid());
   EXPECT_TRUE(f5.is_error);
   EXPECT_EQ(s5, can::tostring(f5, true));
+}
 
+TEST(StringTest, stringConversion5)
+{
   const std::string s6("40001337#1234567812345678");
   can::Frame f6 = can::toframe(s6);
   EXPECT_EQ(f6.fullid(), 0xC0001337);
   EXPECT_TRUE(f6.isValid());
   EXPECT_TRUE(f6.is_rtr);
   EXPECT_EQ(s6, can::tostring(f6, true));
+}
 
+TEST(StringTest, stringConversion6)
+{
+  const std::string s1fd("123##1123456781234567811223344");
+  can::Frame f1fd = can::toframe(s1fd);
+  EXPECT_EQ(f1fd.id, 0x123);
+  EXPECT_EQ(f1fd.dlc, 12);
+  EXPECT_EQ(f1fd.flags, 1);
+  EXPECT_EQ(f1fd.is_fd, true);
+  EXPECT_EQ(s1fd, can::tostring(f1fd, true));
 }
 
 // Run all the tests that were declared with TEST()


### PR DESCRIPTION
So, this is a bold pull request, sine it breaks compatibility with can_msgs/Frame due to changed array type. Initially I thought of using the MSB of can_msgs/Frame.dlc to indicate a bit rate switch to avoid changing the message at all, but I soon realized that the 8 bytes was hard coded. It will break both compatibility with old bags and users will need to reserve memory themselves for their data. At the same time I don't want to add a new message for FD frames, which would be the only option to preserve compatibility, because this would remove much of the transparency between CAN and CAN FD.

What do you think of this?