### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/can_msgs/CMakeLists.txt
+++ b/can_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(can_msgs)
 
 if(NOT CMAKE_CXX_STANDARD)

--- a/canopen_402/CMakeLists.txt
+++ b/canopen_402/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(canopen_402)
 
 if(NOT CMAKE_CXX_STANDARD)

--- a/canopen_chain_node/CMakeLists.txt
+++ b/canopen_chain_node/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(canopen_chain_node)
 
 if(NOT CMAKE_CXX_STANDARD)

--- a/canopen_master/CMakeLists.txt
+++ b/canopen_master/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(canopen_master)
 
 if(NOT CMAKE_CXX_STANDARD)

--- a/canopen_motor_node/CMakeLists.txt
+++ b/canopen_motor_node/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(canopen_motor_node)
 
 if(NOT CMAKE_CXX_STANDARD)

--- a/ros_canopen/CMakeLists.txt
+++ b/ros_canopen/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ros_canopen)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/socketcan_bridge/CMakeLists.txt
+++ b/socketcan_bridge/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(socketcan_bridge)
 
 if(NOT CMAKE_CXX_STANDARD)

--- a/socketcan_interface/CMakeLists.txt
+++ b/socketcan_interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(socketcan_interface)
 
 if(NOT CMAKE_CXX_STANDARD)


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

Signed-off-by: ahcorde <ahcorde@gmail.com>