### PR TITLE
fix: Use variable to catch fast NMT state transitions

### DIFF
--- a/canopen_master/include/canopen_master/canopen.h
+++ b/canopen_master/include/canopen_master/canopen.h
@@ -247,6 +247,7 @@ private:
     void switchState(const uint8_t &s);
 
     State state_;
+    State wait_for_state_;
     SDOClient sdo_;
     PDOMapper pdo_;
 


### PR DESCRIPTION
Solves #435, by storing the desired state in a variable (`wait_for_state_`). This way [`wait_for()`](https://github.com/ros-industrial/ros_canopen/blob/b80d5904c4c1bd32be25f84d3cca1fe6a6dc5719/canopen_master/src/node.cpp#L122) can cope with fast NMT state transitions. 