### PR TITLE
Parameter to choose whether to stop the control on internal limit

### DIFF
--- a/canopen_402/include/canopen_402/motor.h
+++ b/canopen_402/include/canopen_402/motor.h
@@ -296,7 +296,8 @@ public:
     : MotorBase(name), status_word_(0),control_word_(0),
       switching_state_(State402::InternalState(settings.get_optional<unsigned int>("switching_state", static_cast<unsigned int>(State402::Operation_Enable)))),
       monitor_mode_(settings.get_optional<bool>("monitor_mode", true)),
-      state_switch_timeout_(settings.get_optional<unsigned int>("state_switch_timeout", 5))
+      state_switch_timeout_(settings.get_optional<unsigned int>("state_switch_timeout", 5)),
+      stop_on_internal_limit_(settings.get_optional<bool>("stop_on_internal_limit", true))
     {
         storage->entry(status_word_entry_, 0x6041);
         storage->entry(control_word_entry_, 0x6040);
@@ -377,6 +378,7 @@ private:
     const State402::InternalState switching_state_;
     const bool monitor_mode_;
     const boost::chrono::seconds state_switch_timeout_;
+    const bool stop_on_internal_limit_;
 
     canopen::ObjectStorage::Entry<uint16_t>  status_word_entry_;
     canopen::ObjectStorage::Entry<uint16_t >  control_word_entry_;

--- a/canopen_402/src/motor.cpp
+++ b/canopen_402/src/motor.cpp
@@ -397,7 +397,7 @@ bool Motor402::readState(LayerStatus &status, const LayerState &current_state){
         status.warn("mode does not match");
     }
     if(sw & (1<<State402::SW_Internal_limit)){
-        if(old_sw & (1<<State402::SW_Internal_limit) || current_state != Ready){
+        if(!stop_on_internal_limit_ || old_sw & (1<<State402::SW_Internal_limit) || current_state != Ready){
             status.warn("Internal limit active");
         }else{
             status.error("Internal limit active");


### PR DESCRIPTION
The canopen_motor_node stops the servo control when an internal limit occurs.
But the motor driver boards on our robot can continue to operate with the internal limit.
At that time, the control (e.g., current) is appropriately limited to the set value.
So, it is not necessary to always stop the control.
In some cases, we want to continue the operation by using the limiting functions provided by the board.
Therefore, we have added a setting parameter to choose whether or not to stop the servo control when an internal limit occurs.
