### PR TITLE
To resolve the socketcan interface dying due to can errors and failing to recover

### DIFF
--- a/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
+++ b/socketcan_bridge/include/socketcan_bridge/socketcan_to_topic.h
@@ -50,10 +50,11 @@ class SocketCANToTopic
 
     can::FrameListenerConstSharedPtr frame_listener_;
     can::StateListenerConstSharedPtr state_listener_;
-
+    ros::Timer timer;
 
     void frameCallback(const can::Frame& f);
     void stateCallback(const can::State & s);
+    void timerCallback(const ros::TimerEvent & Event);
 };
 
 void convertSocketCANToMessage(const can::Frame& f, can_msgs::Frame& m)

--- a/socketcan_bridge/include/socketcan_bridge/topic_to_socketcan.h
+++ b/socketcan_bridge/include/socketcan_bridge/topic_to_socketcan.h
@@ -45,9 +45,11 @@ class TopicToSocketCAN
     can::DriverInterfaceSharedPtr driver_;
 
     can::StateListenerConstSharedPtr state_listener_;
+    ros::Timer timer;
 
     void msgCallback(const can_msgs::Frame::ConstPtr& msg);
     void stateCallback(const can::State & s);
+    void timerCallback(const ros::TimerEvent& Event );
 };
 
 void convertMessageToSocketCAN(const can_msgs::Frame& m, can::Frame& f)

--- a/socketcan_bridge/src/socketcan_to_topic.cpp
+++ b/socketcan_bridge/src/socketcan_to_topic.cpp
@@ -55,6 +55,7 @@ namespace socketcan_bridge
       can_topic_ = nh->advertise<can_msgs::Frame>("received_messages",
                                                   nh_param->param("received_messages_queue_size", 10));
       driver_ = driver;
+      timer = nh->createTimer(ros::Duration(0.1), std::bind(&SocketCANToTopic::timerCallback, this, std::placeholders::_1));
     };
 
   void SocketCANToTopic::setup()
@@ -85,7 +86,13 @@ namespace socketcan_bridge
        if (nh.getParam("can_ids", filters)) return setup(filters);
        return setup();
   }
-
+  void SocketCANToTopic::timerCallback(const ros::TimerEvent& Event )
+  {
+    if(!driver_->getState().isReady())
+    {
+        driver_->recover();
+    }
+  }
 
   void SocketCANToTopic::frameCallback(const can::Frame& f)
     {

--- a/socketcan_bridge/src/topic_to_socketcan.cpp
+++ b/socketcan_bridge/src/topic_to_socketcan.cpp
@@ -37,6 +37,7 @@ namespace socketcan_bridge
       can_topic_ = nh->subscribe<can_msgs::Frame>("sent_messages", nh_param->param("sent_messages_queue_size", 10),
                     std::bind(&TopicToSocketCAN::msgCallback, this, std::placeholders::_1));
       driver_ = driver;
+      timer = nh->createTimer(ros::Duration(0.1), std::bind(&TopicToSocketCAN::timerCallback, this, std::placeholders::_1));
     };
 
   void TopicToSocketCAN::setup()
@@ -44,7 +45,13 @@ namespace socketcan_bridge
       state_listener_ = driver_->createStateListener(
               std::bind(&TopicToSocketCAN::stateCallback, this, std::placeholders::_1));
     };
-
+  void TopicToSocketCAN::timerCallback(const ros::TimerEvent& Event )
+  {
+    if(!driver_->getState().isReady())
+    {
+        driver_->recover();
+    }
+  }
   void TopicToSocketCAN::msgCallback(const can_msgs::Frame::ConstPtr& msg)
     {
       // ROS_DEBUG("Message came from sent_messages topic");

--- a/socketcan_interface/include/socketcan_interface/threading.h
+++ b/socketcan_interface/include/socketcan_interface/threading.h
@@ -84,9 +84,9 @@ public:
             thread_->join();
         }
     }
-    virtual void recover(){
+    virtual bool recover(){
         shutdown();
-        init(device_,loopback_,settings_);
+        return init(device_,loopback_,settings_);
         }
     virtual ~ThreadedInterface() {
         shutdown_internal();

--- a/socketcan_interface/include/socketcan_interface/threading.h
+++ b/socketcan_interface/include/socketcan_interface/threading.h
@@ -38,6 +38,9 @@ public:
 
 template<typename WrappedInterface> class ThreadedInterface : public WrappedInterface{
     std::shared_ptr<boost::thread> thread_;
+    SettingsConstSharedPtr settings_;
+    std::string device_;
+    bool loopback_;
     void run_thread(){
         WrappedInterface::run();
     }
@@ -61,6 +64,9 @@ public:
         #pragma GCC diagnostic pop
     }
     virtual bool init(const std::string &device, bool loopback, SettingsConstSharedPtr settings) override {
+        device_ =  device;
+        loopback_ = loopback;
+        settings_ = settings;
         if(!thread_ && WrappedInterface::init(device, loopback, settings)){
             StateWaiter waiter(this);
             thread_.reset(new boost::thread(&ThreadedInterface::run_thread, this));
@@ -78,6 +84,10 @@ public:
             thread_->join();
         }
     }
+    virtual void recover(){
+        shutdown();
+        init(device_,loopback_,settings_);
+        }
     virtual ~ThreadedInterface() {
         shutdown_internal();
     }


### PR DESCRIPTION
This is to solve issue #468. A ros timer is started to check the driver state after every specified duration and to reinitialize the driver for the node if the driver has recovered.