### PR TITLE
Use correct index with check_com_changed

### DIFF
--- a/canopen_master/src/pdo.cpp
+++ b/canopen_master/src/pdo.cpp
@@ -104,7 +104,7 @@ void PDOMapper::PDO::parse_and_set_mapping(const ObjectStorageSharedPtr &storage
     ObjectStorage::Entry<uint32_t> cob_id;
     storage->entry(cob_id, com_index, SUB_COM_COB_ID);
 
-    bool com_changed = check_com_changed(dict, map_index);
+    bool com_changed = check_com_changed(dict, com_index);
     if((map_changed || com_changed) && cob_id.desc().writable){
         cob_id.set(cob_id.get() | PDOid::INVALID_MASK);
     }


### PR DESCRIPTION
Now correctly checks if the communication parameters need to be written. I guess this issue was masked because the mapping parameters are usually changed as well. Came across this when configuring a drive (AMC DZCANTE-012L080) with read-only RPDO mapping parameters and read-write communication parameters.