### PR TITLE
use default C++ standard instead of 14

### DIFF
--- a/can_msgs/CMakeLists.txt
+++ b/can_msgs/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(can_msgs)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 find_package(catkin REQUIRED
   COMPONENTS
     message_generation

--- a/canopen_402/CMakeLists.txt
+++ b/canopen_402/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(canopen_402)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 find_package(catkin REQUIRED
   COMPONENTS
     canopen_master

--- a/canopen_chain_node/CMakeLists.txt
+++ b/canopen_chain_node/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(canopen_chain_node)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 find_package(catkin REQUIRED
   COMPONENTS
     canopen_master

--- a/canopen_master/CMakeLists.txt
+++ b/canopen_master/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(canopen_master)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 find_package(catkin REQUIRED
   COMPONENTS
     class_loader

--- a/canopen_motor_node/CMakeLists.txt
+++ b/canopen_motor_node/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(canopen_motor_node)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 find_package(catkin REQUIRED
   COMPONENTS
     canopen_402

--- a/socketcan_bridge/CMakeLists.txt
+++ b/socketcan_bridge/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(socketcan_bridge)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 find_package(catkin REQUIRED
   COMPONENTS
     can_msgs

--- a/socketcan_interface/CMakeLists.txt
+++ b/socketcan_interface/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(socketcan_interface)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 find_package(catkin REQUIRED
   COMPONENTS
     class_loader


### PR DESCRIPTION
I get this when trying to compile in Ubuntu 22.04:

```
.../src/drivers/ros_canopen/socketcan_bridge/src/socketcan_to_topic.cpp:28:
/usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
    10 |     typedef std::shared_mutex shared_mutex;
       |                  ^~~~~~~~~~~~
 /usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
    10 |     typedef std::shared_mutex shared_mutex;
       |             ^~~
make[2]: *** [CMakeFiles/socketcan_to_topic.dir/build.make:90: CMakeFiles/socketcan_to_topic.dir/src/socketcan_to_topic.cpp.o] 
```

Using the default 22.04 C++ standard (17 I think) fixes it.

This would more accurately be part of a `noetic` branch which would mean the default C++ standard is already 14.